### PR TITLE
Consistent API for object input validation

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -10,7 +10,6 @@ jobs:
   pint:
     name: "Running Laravel Pint check"
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
 

--- a/src/Artisan/stubs/value-object.stub
+++ b/src/Artisan/stubs/value-object.stub
@@ -24,7 +24,7 @@ class {{ class }} extends ValueObject
      */
     public function __construct()
     {
-        //
+        $this->validate();
     }
 
     /**
@@ -55,5 +55,15 @@ class {{ class }} extends ValueObject
     public function __toString(): string
     {
         // TODO: Implement value() method.
+    }
+
+    /**
+     * Validate the value object data.
+     *
+     * @return void
+     */
+    protected function validate(): void
+    {
+        // TODO: Implement validate() method.
     }
 }

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -100,8 +100,8 @@ class ClassString extends ValueObject
      */
     protected function validate(): void
     {
-        if (blank($this->string)) {
-            throw new \InvalidArgumentException('Class string cannot be blank.');
+        if (empty($this->string)) {
+            throw new \InvalidArgumentException('Class string cannot be empty.');
         }
     }
 }

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -78,7 +78,7 @@ class ClassString extends ValueObject
      *
      * @return object
      */
-    public function instantiateWith(array $parameters = []): object
+    public function instantiateWith(array $parameters): object
     {
         return $this->instantiate($parameters);
     }

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -94,7 +94,7 @@ class ClassString extends ValueObject
     }
 
     /**
-     * Verify the value object input.
+     * Validate the value object data.
      *
      * @return void
      */

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -100,7 +100,7 @@ class ClassString extends ValueObject
      */
     protected function validate(): void
     {
-        if (empty($this->string)) {
+        if (empty($this->value())) {
             throw new \InvalidArgumentException('Class string cannot be empty.');
         }
     }

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace MichaelRubel\ValueObjects\Collection\Complex;
 
+use InvalidArgumentException;
 use MichaelRubel\ValueObjects\ValueObject;
 
 /**
@@ -101,7 +102,7 @@ class ClassString extends ValueObject
     protected function validate(): void
     {
         if (empty($this->value())) {
-            throw new \InvalidArgumentException('Class string cannot be empty.');
+            throw new InvalidArgumentException('Class string cannot be empty.');
         }
     }
 }

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -100,7 +100,7 @@ class ClassString extends ValueObject
      */
     protected function validate(): void
     {
-        if (empty($this->string)) {
+        if (blank($this->string)) {
             throw new \InvalidArgumentException('Class string cannot be empty.');
         }
     }

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -23,8 +23,8 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string|null $string)
- * @method static static from(string|null $string)
+ * @method static static make(string $string)
+ * @method static static from(string $string)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -32,11 +32,11 @@ class ClassString extends ValueObject
     /**
      * Create a new instance of the value object.
      *
-     * @param  string|null  $string
+     * @param  string  $string
      */
-    public function __construct(protected ?string $string)
+    public function __construct(protected string $string)
     {
-        //
+        $this->validate();
     }
 
     /**
@@ -90,6 +90,18 @@ class ClassString extends ValueObject
      */
     public function value(): string
     {
-        return (string) $this->string;
+        return $this->string;
+    }
+
+    /**
+     * Verify the value object input.
+     *
+     * @return void
+     */
+    protected function validate(): void
+    {
+        if (empty($this->string)) {
+            throw new \InvalidArgumentException('Class string cannot be empty.');
+        }
     }
 }

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -101,7 +101,7 @@ class ClassString extends ValueObject
     protected function validate(): void
     {
         if (blank($this->string)) {
-            throw new \InvalidArgumentException('Class string cannot be empty.');
+            throw new \InvalidArgumentException('Class string cannot be blank.');
         }
     }
 }

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -104,7 +104,7 @@ class FullName extends ValueObject
     }
 
     /**
-     * Verify the value object input.
+     * Validate the value object data.
      *
      * @return void
      */

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace MichaelRubel\ValueObjects\Collection\Complex;
 
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use MichaelRubel\Formatters\Collection\FullNameFormatter;
 use MichaelRubel\ValueObjects\ValueObject;
 
@@ -111,7 +112,7 @@ class FullName extends ValueObject
     protected function validate(): void
     {
         if (empty($this->value())) {
-            throw new \InvalidArgumentException('Full name cannot be empty.');
+            throw new InvalidArgumentException('Full name cannot be empty.');
         }
     }
 

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -111,7 +111,7 @@ class FullName extends ValueObject
     protected function validate(): void
     {
         if (blank($this->value)) {
-            throw new \InvalidArgumentException('Full name cannot be empty.');
+            throw new \InvalidArgumentException('Full name cannot be blank.');
         }
     }
 

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -56,7 +56,7 @@ class FullName extends ValueObject
      */
     public function fullName(): string
     {
-        return (string) $this->value;
+        return $this->value;
     }
 
     /**

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -66,7 +66,7 @@ class FullName extends ValueObject
      */
     public function firstName(): string
     {
-        return $this->split->first();
+        return (string) $this->split->first();
     }
 
     /**
@@ -76,7 +76,7 @@ class FullName extends ValueObject
      */
     public function lastName(): string
     {
-        return $this->split->last();
+        return (string) $this->split->last();
     }
 
     /**

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -25,8 +25,8 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string|null $value)
- * @method static static from(string|null $value)
+ * @method static static make(string $value)
+ * @method static static from(string $value)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -110,7 +110,7 @@ class FullName extends ValueObject
      */
     protected function validate(): void
     {
-        if (empty($this->value)) {
+        if (blank($this->value)) {
             throw new \InvalidArgumentException('Full name cannot be empty.');
         }
     }

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -110,8 +110,8 @@ class FullName extends ValueObject
      */
     protected function validate(): void
     {
-        if (blank($this->value)) {
-            throw new \InvalidArgumentException('Full name cannot be blank.');
+        if (empty($this->value)) {
+            throw new \InvalidArgumentException('Full name cannot be empty.');
         }
     }
 

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -44,10 +44,9 @@ class FullName extends ValueObject
      */
     public function __construct(protected string $value)
     {
+        $this->split();
+        $this->format();
         $this->validate();
-
-        $this->value = $this->format();
-        $this->split = $this->split();
     }
 
     /**
@@ -114,25 +113,29 @@ class FullName extends ValueObject
         if (empty($this->value())) {
             throw new InvalidArgumentException('Full name cannot be empty.');
         }
+
+        if (count($this->split) < 2) {
+            throw new InvalidArgumentException('Full name should have a first name and last name.');
+        }
     }
 
     /**
      * Format the value.
      *
-     * @return string
+     * @return void
      */
-    protected function format(): string
+    protected function format(): void
     {
-        return format(FullNameFormatter::class, $this->value());
+        $this->value = format(FullNameFormatter::class, $this->value());
     }
 
     /**
      * Split the value.
      *
-     * @return Collection<int, string>
+     * @return void
      */
-    protected function split(): Collection
+    protected function split(): void
     {
-        return str($this->value())->split('/\s/');
+        $this->split = str($this->value())->split('/\s/');
     }
 }

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -62,9 +62,9 @@ class FullName extends ValueObject
     /**
      * Get the first name.
      *
-     * @return string|null
+     * @return string
      */
-    public function firstName(): ?string
+    public function firstName(): string
     {
         return $this->split->first();
     }
@@ -72,9 +72,9 @@ class FullName extends ValueObject
     /**
      * Get the last name.
      *
-     * @return string|null
+     * @return string
      */
-    public function lastName(): ?string
+    public function lastName(): string
     {
         return $this->split->last();
     }

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -110,7 +110,7 @@ class FullName extends ValueObject
      */
     protected function validate(): void
     {
-        if (empty($this->value)) {
+        if (empty($this->value())) {
             throw new \InvalidArgumentException('Full name cannot be empty.');
         }
     }

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -39,10 +39,12 @@ class FullName extends ValueObject
     /**
      * Create a new instance of the value object.
      *
-     * @param  string|null  $value
+     * @param  string  $value
      */
-    public function __construct(protected ?string $value)
+    public function __construct(protected string $value)
     {
+        $this->validate();
+
         $this->value = $this->format();
         $this->split = $this->split();
     }
@@ -88,6 +90,32 @@ class FullName extends ValueObject
     }
 
     /**
+     * Get an array representation of the value object.
+     *
+     * @return array<string, string|null>
+     */
+    public function toArray(): array
+    {
+        return [
+            'fullName'  => $this->fullName(),
+            'firstName' => $this->firstName(),
+            'lastName'  => $this->lastName(),
+        ];
+    }
+
+    /**
+     * Verify the value object input.
+     *
+     * @return void
+     */
+    protected function validate(): void
+    {
+        if (empty($this->value)) {
+            throw new \InvalidArgumentException('Full name cannot be empty.');
+        }
+    }
+
+    /**
      * Format the value.
      *
      * @return string
@@ -105,19 +133,5 @@ class FullName extends ValueObject
     protected function split(): Collection
     {
         return str($this->value())->split('/\s/');
-    }
-
-    /**
-     * Get an array representation of the value object.
-     *
-     * @return array<string, string|null>
-     */
-    public function toArray(): array
-    {
-        return [
-            'fullName'  => $this->fullName(),
-            'firstName' => $this->firstName(),
-            'lastName'  => $this->lastName(),
-        ];
     }
 }

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -155,7 +155,7 @@ class TaxNumber extends ValueObject
     }
 
     /**
-     * Verify the value object input.
+     * Validate the value object data.
      *
      * @return void
      */

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -33,13 +33,15 @@ class TaxNumber extends ValueObject
     /**
      * Create a new instance of the value object.
      *
-     * @param  string|null  $number
+     * @param  string  $number
      * @param  string|null  $prefix
      */
     public function __construct(
-        protected ?string $number = null,
+        protected string $number,
         protected ?string $prefix = null,
     ) {
+        $this->validate();
+
         $this->number = $this->format();
 
         if ($this->canSplit()) {
@@ -102,6 +104,20 @@ class TaxNumber extends ValueObject
     }
 
     /**
+     * Get an array representation of the value object.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'fullTaxNumber' => $this->fullTaxNumber(),
+            'taxNumber'     => $this->taxNumber(),
+            'prefix'        => $this->prefix(),
+        ];
+    }
+
+    /**
      * Format the value.
      *
      * @return string
@@ -139,16 +155,14 @@ class TaxNumber extends ValueObject
     }
 
     /**
-     * Get an array representation of the value object.
+     * Verify the value object input.
      *
-     * @return array
+     * @return void
      */
-    public function toArray(): array
+    protected function validate(): void
     {
-        return [
-            'fullTaxNumber' => $this->fullTaxNumber(),
-            'taxNumber'     => $this->taxNumber(),
-            'prefix'        => $this->prefix(),
-        ];
+        if (empty($this->number)) {
+            throw new \InvalidArgumentException('Tax number cannot be empty.');
+        }
     }
 }

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -162,7 +162,7 @@ class TaxNumber extends ValueObject
     protected function validate(): void
     {
         if (blank($this->number)) {
-            throw new \InvalidArgumentException('Tax number cannot be empty.');
+            throw new \InvalidArgumentException('Tax number cannot be blank.');
         }
     }
 }

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -161,7 +161,7 @@ class TaxNumber extends ValueObject
      */
     protected function validate(): void
     {
-        if (empty($this->number)) {
+        if (empty($this->value())) {
             throw new \InvalidArgumentException('Tax number cannot be empty.');
         }
     }

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -161,7 +161,7 @@ class TaxNumber extends ValueObject
      */
     protected function validate(): void
     {
-        if (empty($this->number)) {
+        if (blank($this->number)) {
             throw new \InvalidArgumentException('Tax number cannot be empty.');
         }
     }

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -42,8 +42,7 @@ class TaxNumber extends ValueObject
         protected ?string $prefix = null,
     ) {
         $this->validate();
-
-        $this->number = $this->format();
+        $this->format();
 
         if ($this->canSplit()) {
             $this->split();
@@ -119,13 +118,25 @@ class TaxNumber extends ValueObject
     }
 
     /**
+     * Validate the value object data.
+     *
+     * @return void
+     */
+    protected function validate(): void
+    {
+        if (empty($this->value())) {
+            throw new InvalidArgumentException('Tax number cannot be empty.');
+        }
+    }
+
+    /**
      * Format the value.
      *
-     * @return string
+     * @return void
      */
-    protected function format(): string
+    protected function format(): void
     {
-        return format(TaxNumberFormatter::class, $this->taxNumber(), $this->prefix());
+        $this->number = format(TaxNumberFormatter::class, $this->taxNumber(), $this->prefix());
     }
 
     /**
@@ -153,17 +164,5 @@ class TaxNumber extends ValueObject
         $this->number = str($this->number)
             ->substr(2)
             ->value();
-    }
-
-    /**
-     * Validate the value object data.
-     *
-     * @return void
-     */
-    protected function validate(): void
-    {
-        if (empty($this->value())) {
-            throw new InvalidArgumentException('Tax number cannot be empty.');
-        }
     }
 }

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace MichaelRubel\ValueObjects\Collection\Complex;
 
+use InvalidArgumentException;
 use MichaelRubel\Formatters\Collection\TaxNumberFormatter;
 use MichaelRubel\ValueObjects\ValueObject;
 
@@ -162,7 +163,7 @@ class TaxNumber extends ValueObject
     protected function validate(): void
     {
         if (empty($this->value())) {
-            throw new \InvalidArgumentException('Tax number cannot be empty.');
+            throw new InvalidArgumentException('Tax number cannot be empty.');
         }
     }
 }

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -161,8 +161,8 @@ class TaxNumber extends ValueObject
      */
     protected function validate(): void
     {
-        if (blank($this->number)) {
-            throw new \InvalidArgumentException('Tax number cannot be blank.');
+        if (empty($this->number)) {
+            throw new \InvalidArgumentException('Tax number cannot be empty.');
         }
     }
 }

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -24,8 +24,8 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string|null $number, string|null $prefix = null)
- * @method static static from(string|null $number, string|null $prefix = null)
+ * @method static static make(string $number, string|null $prefix = null)
+ * @method static static from(string $number, string|null $prefix = null)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Complex/Uuid.php
+++ b/src/Collection/Complex/Uuid.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace MichaelRubel\ValueObjects\Collection\Complex;
 
+use InvalidArgumentException;
 use MichaelRubel\ValueObjects\ValueObject;
 
 /**
@@ -93,7 +94,7 @@ class Uuid extends ValueObject
     protected function validate(): void
     {
         if (! str($this->value())->isUuid()) {
-            throw new \InvalidArgumentException('UUID is invalid.');
+            throw new InvalidArgumentException('UUID is invalid.');
         }
     }
 }

--- a/src/Collection/Complex/Uuid.php
+++ b/src/Collection/Complex/Uuid.php
@@ -92,7 +92,7 @@ class Uuid extends ValueObject
      */
     protected function validate(): void
     {
-        if (! str($this->value)->isUuid()) {
+        if (! str($this->value())->isUuid()) {
             throw new \InvalidArgumentException('UUID is invalid.');
         }
     }

--- a/src/Collection/Complex/Uuid.php
+++ b/src/Collection/Complex/Uuid.php
@@ -87,7 +87,7 @@ class Uuid extends ValueObject
     }
 
     /**
-     * Verify the value object input.
+     * Validate the value object data.
      *
      * @return void
      */

--- a/src/Collection/Complex/Uuid.php
+++ b/src/Collection/Complex/Uuid.php
@@ -40,9 +40,7 @@ class Uuid extends ValueObject
         protected string $value,
         protected ?string $name = null,
     ) {
-        if (! Str::isUuid($this->value)) {
-            throw new \InvalidArgumentException('UUID is invalid.');
-        }
+        $this->validate();
     }
 
     /**
@@ -86,5 +84,17 @@ class Uuid extends ValueObject
             'name'  => $this->name(),
             'value' => $this->value(),
         ];
+    }
+
+    /**
+     * Verify the value object input.
+     *
+     * @return void
+     */
+    protected function validate(): void
+    {
+        if (! Str::isUuid($this->value)) {
+            throw new \InvalidArgumentException('UUID is invalid.');
+        }
     }
 }

--- a/src/Collection/Complex/Uuid.php
+++ b/src/Collection/Complex/Uuid.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace MichaelRubel\ValueObjects\Collection\Complex;
 
-use Illuminate\Support\Str;
 use MichaelRubel\ValueObjects\ValueObject;
 
 /**
@@ -93,7 +92,7 @@ class Uuid extends ValueObject
      */
     protected function validate(): void
     {
-        if (! Str::isUuid($this->value)) {
+        if (! str($this->value)->isUuid()) {
             throw new \InvalidArgumentException('UUID is invalid.');
         }
     }

--- a/src/Collection/Primitive/Boolean.php
+++ b/src/Collection/Primitive/Boolean.php
@@ -54,7 +54,7 @@ class Boolean extends ValueObject
         $this->value = match (true) {
             $this->isInTrueValues()  => true,
             $this->isInFalseValues() => false,
-            default => throw new InvalidArgumentException('Invalid boolean'),
+            default => throw new InvalidArgumentException('Invalid boolean.'),
         };
     }
 

--- a/src/Collection/Primitive/Boolean.php
+++ b/src/Collection/Primitive/Boolean.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace MichaelRubel\ValueObjects\Collection\Primitive;
 
+use InvalidArgumentException;
 use MichaelRubel\ValueObjects\ValueObject;
 
 /**
@@ -53,7 +54,7 @@ class Boolean extends ValueObject
         $this->value = match (true) {
             $this->isInTrueValues()  => true,
             $this->isInFalseValues() => false,
-            default => throw new \InvalidArgumentException('Invalid boolean'),
+            default => throw new InvalidArgumentException('Invalid boolean'),
         };
     }
 

--- a/src/Collection/Primitive/Text.php
+++ b/src/Collection/Primitive/Text.php
@@ -23,8 +23,8 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string|Stringable|null $value)
- * @method static static from(string|Stringable|null $value)
+ * @method static static make(string|Stringable $value)
+ * @method static static from(string|Stringable $value)
  *
  * @extends ValueObject<TKey, TValue>
  */
@@ -33,11 +33,11 @@ class Text extends ValueObject
     /**
      * Create a new instance of the value object.
      *
-     * @param  string|Stringable|null  $value
+     * @param  string|Stringable  $value
      */
-    public function __construct(protected string|Stringable|null $value)
+    public function __construct(protected string|Stringable $value)
     {
-        //
+        $this->validate();
     }
 
     /**
@@ -48,5 +48,17 @@ class Text extends ValueObject
     public function value(): string
     {
         return (string) $this->value;
+    }
+
+    /**
+     * Validate the value object data.
+     *
+     * @return void
+     */
+    protected function validate(): void
+    {
+        if (empty($this->value())) {
+            throw new \InvalidArgumentException('Text cannot be empty.');
+        }
     }
 }

--- a/src/Collection/Primitive/Text.php
+++ b/src/Collection/Primitive/Text.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace MichaelRubel\ValueObjects\Collection\Primitive;
 
 use Illuminate\Support\Stringable;
+use InvalidArgumentException;
 use MichaelRubel\ValueObjects\ValueObject;
 
 /**
@@ -58,7 +59,7 @@ class Text extends ValueObject
     protected function validate(): void
     {
         if (empty($this->value())) {
-            throw new \InvalidArgumentException('Text cannot be empty.');
+            throw new InvalidArgumentException('Text cannot be empty.');
         }
     }
 }

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -7,6 +7,7 @@ namespace MichaelRubel\ValueObjects;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 
 /**
  * @template TKey of array-key
@@ -116,6 +117,6 @@ abstract class ValueObject implements Arrayable
      */
     public function __set(string $name, mixed $value): void
     {
-        throw new \InvalidArgumentException('Value objects are immutable. You cannot modify properties, create a new object instead.');
+        throw new InvalidArgumentException('Value objects are immutable, you cannot modify properties. Create a new object instead.');
     }
 }

--- a/tests/Unit/Complex/ClassStringTest.php
+++ b/tests/Unit/Complex/ClassStringTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Olsza\ValueObjects\Tests\Feature\ValueObjects;
 
 use Illuminate\Contracts\Container\BindingResolutionException;

--- a/tests/Unit/Complex/ClassStringTest.php
+++ b/tests/Unit/Complex/ClassStringTest.php
@@ -2,6 +2,7 @@
 
 namespace Olsza\ValueObjects\Tests\Feature\ValueObjects;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
 use MichaelRubel\ValueObjects\Collection\Complex\ClassString;
 use MichaelRubel\ValueObjects\Tests\TestCase;
 
@@ -23,11 +24,19 @@ test('can get class string', function () {
     $this->assertSame('My\Test\Class', $classString->value());
 });
 
-test('class string not instantiable and class and interface are undefined', function () {
-    $classString = new ClassString('My\Test\Class\NotInstantiable');
+test('class string non-instantiable and class and interface are undefined', function () {
+    $classString = new ClassString('My\Test\Class\NonInstantiable');
 
     $this->assertFalse($classString->classExists());
     $this->assertFalse($classString->interfaceExists());
+});
+
+test('class string throws binding resolution exception when trying to instantiate non-instantiable class', function () {
+    $classString = new ClassString('My\Test\Class\NonInstantiable');
+
+    $this->expectException(BindingResolutionException::class);
+
+    $classString->instantiate();
 });
 
 test('class string is exists but interface dont', function () {

--- a/tests/Unit/Complex/ClassStringTest.php
+++ b/tests/Unit/Complex/ClassStringTest.php
@@ -1,17 +1,20 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Olsza\ValueObjects\Tests\Feature\ValueObjects;
 
 use MichaelRubel\ValueObjects\Collection\Complex\ClassString;
 use MichaelRubel\ValueObjects\Tests\TestCase;
 
-test('class string is empty string', function () {
-    $classString = new ClassString('');
+test('class string cannot be empty string', function () {
+    $this->expectException(\InvalidArgumentException::class);
 
-    $this->assertFalse($classString->classExists());
-    $this->assertFalse($classString->interfaceExists());
+    new ClassString('');
+});
+
+test('class string cannot be null', function () {
+    $this->expectException(\TypeError::class);
+
+    new ClassString(null);
 });
 
 test('can get class string', function () {
@@ -45,17 +48,6 @@ test('can cast class string to string', function () {
     $classString = new ClassString(ClassString::class);
 
     $this->assertSame('MichaelRubel\ValueObjects\Collection\Complex\ClassString', (string) $classString);
-});
-
-test('class string is null', function () {
-    $classString = new ClassString('');
-    $this->assertSame('', $classString->value());
-
-    $classString = new ClassString(null);
-    $this->assertSame('', $classString->value());
-
-    $classString = new ClassString(null);
-    $this->assertSame('', (string) $classString);
 });
 
 test('can instantiate a class from class string value', function () {

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -5,13 +5,13 @@ namespace Olsza\ValueObjects\Tests\Feature\ValueObjects;
 use MichaelRubel\ValueObjects\Collection\Complex\FullName;
 
 test('can get first name', function () {
-    $name = new FullName('Michael');
+    $name = new FullName('Michael Rubél');
 
     $this->assertSame('Michael', $name->firstName());
 });
 
 test('can get last name', function () {
-    $name = new FullName('Rubél');
+    $name = new FullName('Michael Rubél');
 
     $this->assertSame('Rubél', $name->lastName());
 });
@@ -51,8 +51,8 @@ test('can get cast to string', function () {
 
 test('cannot pass empty string', function () {
     $this->expectException(\InvalidArgumentException::class);
-    $name = new FullName('');
-    $this->assertSame('', $name->fullName());
+
+    new FullName('');
 });
 
 test('cannot pass null', function () {
@@ -99,6 +99,12 @@ test('full name is arrayable', function () {
 });
 
 test('full name is stringable', function () {
-    $valueObject = new FullName('Name');
+    $valueObject = new FullName('Name Name');
     $this->assertSame($valueObject->value(), (string) $valueObject);
+});
+
+test('full name fails when passed only first name', function () {
+    $this->expectException(\InvalidArgumentException::class);
+
+    new FullName('Name');
 });

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Olsza\ValueObjects\Tests\Feature\ValueObjects;
 
 use MichaelRubel\ValueObjects\Collection\Complex\FullName;
@@ -51,14 +49,15 @@ test('can get cast to string', function () {
     $this->assertSame('Michael Rubél', (string) $name);
 });
 
-test('can pass nulls and returns empty string', function () {
+test('cannot pass empty string', function () {
+    $this->expectException(\InvalidArgumentException::class);
     $name = new FullName('');
     $this->assertSame('', $name->fullName());
+});
 
+test('cannot pass null', function () {
+    $this->expectException(\TypeError::class);
     $name = new FullName(null);
-    $this->assertSame('', $name->fullName());
-
-    $name = new FullName(null, null);
     $this->assertSame('', $name->fullName());
 });
 

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Olsza\ValueObjects\Tests\Feature\ValueObjects;
 
 use MichaelRubel\ValueObjects\Collection\Complex\FullName;

--- a/tests/Unit/Complex/TaxNumberTest.php
+++ b/tests/Unit/Complex/TaxNumberTest.php
@@ -1,16 +1,13 @@
 <?php
 
-declare(strict_types=1);
-
 namespace MichaelRubel\ValueObjects\Tests\Feature\ValueObjects;
 
 use MichaelRubel\ValueObjects\Collection\Complex\TaxNumber;
 
-test('data in tax number is null and country is null', function () {
-    $data = new TaxNumber;
-    $this->assertEmpty($data->prefix());
-    $this->assertEmpty($data->country());
-    $this->assertEmpty($data->taxNumber());
+test('tax number cannot be null', function () {
+    $this->expectException(\TypeError::class);
+
+    new TaxNumber(null);
 });
 
 test('data in tax number is number plus prefix country is null', function () {
@@ -92,71 +89,40 @@ test('tests that are used in the examples in ReadMe', function () {
 });
 
 test('passed null values to value object', function () {
-    $data = new TaxNumber(null, null);
-    $this->assertEquals('', $data->country());
-    $this->assertEquals('', $data->taxNumber());
+    $data = new TaxNumber('AB0123456789', null);
+    $this->assertEquals('AB', $data->country());
+    $this->assertEquals('0123456789', $data->taxNumber());
 
-    $data = (new TaxNumber(null, null))
+    $data = (new TaxNumber('AB0123456789', null))
         ->fullTaxNumber();
-    $this->assertEquals('', $data);
+    $this->assertEquals('AB0123456789', $data);
 
-    $data = new TaxNumber(null, null);
-    $this->assertEquals('', $data->country());
-    $this->assertEquals('', $data->taxNumber());
+    $data = new TaxNumber('AB0123456789', null);
+    $this->assertEquals('AB', $data->country());
+    $this->assertEquals('0123456789', $data->taxNumber());
 
-    $data = (new TaxNumber(null, null))->fullTaxNumber();
-    $this->assertEquals('', $data);
+    $data = (new TaxNumber('AB0123456789', null))->fullTaxNumber();
+    $this->assertEquals('AB0123456789', $data);
 });
 
 test('passed empty values to value object', function () {
-    $data = new TaxNumber('', '');
-    $this->assertEquals('', $data->country());
-    $this->assertEquals('', $data->taxNumber());
+    $data = new TaxNumber('AB0123456789', '');
+    $this->assertEquals('AB', $data->country());
+    $this->assertEquals('0123456789', $data->taxNumber());
 
-    $data = (new TaxNumber('', ''))
+    $data = (new TaxNumber('AB0123456789', ''))
         ->fullTaxNumber();
-    $this->assertEquals('', $data);
+    $this->assertEquals('AB0123456789', $data);
 
-    $data = new TaxNumber('', '');
-    $this->assertEquals('', $data->country());
-    $this->assertEquals('', $data->taxNumber());
+    $data = new TaxNumber('AB0123456789', '');
+    $this->assertEquals('AB', $data->country());
+    $this->assertEquals('0123456789', $data->taxNumber());
 
-    $data = (new TaxNumber('', ''))->fullTaxNumber();
-    $this->assertEquals('', $data);
-});
+    $data = (new TaxNumber('AB0123456789', ''))->fullTaxNumber();
+    $this->assertEquals('AB0123456789', $data);
 
-test('passed empty tax number and null country', function () {
-    $data = new TaxNumber('', null);
-    $this->assertEquals('', $data->country());
-    $this->assertEquals('', $data->taxNumber());
-
-    $data = (new TaxNumber('', null))
-        ->fullTaxNumber();
-    $this->assertEquals('', $data);
-
-    $data = new TaxNumber('', null);
-    $this->assertEquals('', $data->country());
-    $this->assertEquals('', $data->taxNumber());
-
-    $data = (new TaxNumber('', null))->fullTaxNumber();
-    $this->assertEquals('', $data);
-});
-
-test('passed null tax number and empty country', function () {
-    $data = new TaxNumber(null, '');
-    $this->assertEquals('', $data->country());
-    $this->assertEquals('', $data->taxNumber());
-
-    $data = (new TaxNumber(null, ''))
-        ->fullTaxNumber();
-    $this->assertEquals('', $data);
-
-    $data = new TaxNumber(null, '');
-    $this->assertEquals('', $data->country());
-    $this->assertEquals('', $data->taxNumber());
-
-    $data = (new TaxNumber(null, ''))->fullTaxNumber();
-    $this->assertEquals('', $data);
+    $this->expectException(\InvalidArgumentException::class);
+    new TaxNumber('', '');
 });
 
 test('tax number is makeable', function () {

--- a/tests/Unit/Complex/TaxNumberTest.php
+++ b/tests/Unit/Complex/TaxNumberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\ValueObjects\Tests\Feature\ValueObjects;
 
 use MichaelRubel\ValueObjects\Collection\Complex\TaxNumber;

--- a/tests/Unit/Complex/UuidTest.php
+++ b/tests/Unit/Complex/UuidTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Olsza\ValueObjects\Tests\Feature\ValueObjects;
 
 use Illuminate\Support\Str;

--- a/tests/Unit/Complex/UuidTest.php
+++ b/tests/Unit/Complex/UuidTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Olsza\ValueObjects\Tests\Feature\ValueObjects;
 
 use Illuminate\Support\Str;

--- a/tests/Unit/Primitive/TextTest.php
+++ b/tests/Unit/Primitive/TextTest.php
@@ -47,9 +47,10 @@ test('text can accept long text', function () {
     $this->assertSame($string, $text->value());
 });
 
-test('text can accept null', function () {
-    $valueObject = new Text(null);
-    $this->assertSame('', $valueObject->value());
+test('text cannot accept null', function () {
+    $this->expectException(\TypeError::class);
+
+    new Text(null);
 });
 
 test('text fails when no argument passed', function () {
@@ -58,16 +59,18 @@ test('text fails when no argument passed', function () {
     new Text;
 });
 
+test('text fails when empty string passed', function () {
+    $this->expectException(\InvalidArgumentException::class);
+
+    new Text('');
+});
+
 test('text is makeable', function () {
     $valueObject = Text::make('1');
     $this->assertSame('1', $valueObject->value());
-    $valueObject = Text::make(null);
-    $this->assertSame('', $valueObject->value());
 
     $valueObject = Text::from('1');
     $this->assertSame('1', $valueObject->value());
-    $valueObject = Text::from(null);
-    $this->assertSame('', $valueObject->value());
 });
 
 test('text is macroable', function () {
@@ -102,4 +105,15 @@ test('text is stringable', function () {
     $this->assertSame('1.7', (string) $valueObject);
     $valueObject = new Text('1.8');
     $this->assertSame('1.8', (string) $valueObject);
+});
+
+test('text accepts stringable', function () {
+    $valueObject = new Text(str('Lorem ipsum'));
+    $this->assertSame('Lorem ipsum', $valueObject->value());
+});
+
+test('text fails when empty stringable passed', function () {
+    $this->expectException(\InvalidArgumentException::class);
+
+    new Text(str(''));
 });


### PR DESCRIPTION
## About

Added the input validation for most of `Complex` objects. It's a basic `blank` check by default, but the behavior is extracted to the `validate` method that is overrideable by inheritance.

The changes will be tagged as the major release (2.0.0) to avoid breaking applications.

---