### PR TITLE
Add `makeOrNull` method to `ValueObject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ $uuid->uuid(); // '8547d10c-7a37-492a-8d33-be0e5ae6119b'
 $uuid->name(); // 'Optional name'
 ```
 
+## Handle failed validation
+
+If you want to avoid try/catching your value object when the validation fails, you can use `makeOrNull` method:
+
+```php
+Boolean::makeOrNull('wrong input - validation fails'); // null
+```
+
 ## Extending functionality
 All value objects are [Macroable](https://laravel.com/api/9.x/Illuminate/Support/Traits/Macroable.html).
 This way you can add new methods dynamically. If you need to extend existing methods, you can create a value object locally with `make:value-object` command and use inheritance.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ If you want to avoid try/catching your value object when the validation fails, y
 
 ```php
 $bool = Boolean::makeOrNull('bad input'); // null
+
 $bool?->value(); // null
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ $uuid->name(); // 'Optional name'
 If you want to avoid try/catching your value object when the validation fails, you can use `makeOrNull` method:
 
 ```php
-Boolean::makeOrNull('wrong input - validation fails'); // null
+$bool = Boolean::makeOrNull('bad input'); // null
+$bool?->value(); // null
 ```
 
 ## Extending functionality

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -23,9 +23,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static make(string $string)
- * @method static from(string $string)
- * @method static makeOrNull(string $string)
+ * @method static static make(string $string)
+ * @method static static from(string $string)
+ * @method static static makeOrNull(string $string)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -23,8 +23,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string $string)
- * @method static static from(string $string)
+ * @method static make(string $string)
+ * @method static from(string $string)
+ * @method static makeOrNull(string $string)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -25,9 +25,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static make(string $value)
- * @method static from(string $value)
- * @method static makeOrNull(string $value)
+ * @method static static make(string $value)
+ * @method static static from(string $value)
+ * @method static static makeOrNull(string $value)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -25,8 +25,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string $value)
- * @method static static from(string $value)
+ * @method static make(string $value)
+ * @method static from(string $value)
+ * @method static makeOrNull(string $value)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -24,9 +24,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static make(string $number, string|null $prefix = null)
- * @method static from(string $number, string|null $prefix = null)
- * @method static makeOrNull(string $number, string|null $prefix = null)
+ * @method static static make(string $number, string|null $prefix = null)
+ * @method static static from(string $number, string|null $prefix = null)
+ * @method static static makeOrNull(string $number, string|null $prefix = null)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -24,8 +24,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string $number, string|null $prefix = null)
- * @method static static from(string $number, string|null $prefix = null)
+ * @method static make(string $number, string|null $prefix = null)
+ * @method static from(string $number, string|null $prefix = null)
+ * @method static makeOrNull(string $number, string|null $prefix = null)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Complex/Uuid.php
+++ b/src/Collection/Complex/Uuid.php
@@ -23,8 +23,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string $value, string|null $name = null)
- * @method static static from(string $value, string|null $name = null)
+ * @method static make(string $value, string|null $name = null)
+ * @method static from(string $value, string|null $name = null)
+ * @method static makeOrNull(string $value, string|null $name = null)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Complex/Uuid.php
+++ b/src/Collection/Complex/Uuid.php
@@ -23,9 +23,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static make(string $value, string|null $name = null)
- * @method static from(string $value, string|null $name = null)
- * @method static makeOrNull(string $value, string|null $name = null)
+ * @method static static make(string $value, string|null $name = null)
+ * @method static static from(string $value, string|null $name = null)
+ * @method static static makeOrNull(string $value, string|null $name = null)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Primitive/Boolean.php
+++ b/src/Collection/Primitive/Boolean.php
@@ -23,9 +23,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static make(bool|int|string $value)
- * @method static from(bool|int|string $value)
- * @method static makeOrNull(bool|int|string $value)
+ * @method static static make(bool|int|string $value)
+ * @method static static from(bool|int|string $value)
+ * @method static static makeOrNull(bool|int|string $value)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Primitive/Boolean.php
+++ b/src/Collection/Primitive/Boolean.php
@@ -23,8 +23,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(bool|int|string $value)
- * @method static static from(bool|int|string $value)
+ * @method static make(bool|int|string $value)
+ * @method static from(bool|int|string $value)
+ * @method static makeOrNull(bool|int|string $value)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Primitive/Decimal.php
+++ b/src/Collection/Primitive/Decimal.php
@@ -24,9 +24,9 @@ use PHP\Math\BigNumber\BigNumber;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static make(int|string $number, int $scale = 2)
- * @method static from(int|string $number, int $scale = 2)
- * @method static makeOrNull(int|string $number, int $scale = 2)
+ * @method static static make(int|string $number, int $scale = 2)
+ * @method static static from(int|string $number, int $scale = 2)
+ * @method static static makeOrNull(int|string $number, int $scale = 2)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Primitive/Decimal.php
+++ b/src/Collection/Primitive/Decimal.php
@@ -24,8 +24,9 @@ use PHP\Math\BigNumber\BigNumber;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(int|string $number, int $scale = 2)
- * @method static static from(int|string $number, int $scale = 2)
+ * @method static make(int|string $number, int $scale = 2)
+ * @method static from(int|string $number, int $scale = 2)
+ * @method static makeOrNull(int|string $number, int $scale = 2)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Primitive/Integer.php
+++ b/src/Collection/Primitive/Integer.php
@@ -24,8 +24,9 @@ use PHP\Math\BigNumber\BigNumber;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(int|string $number)
- * @method static static from(int|string $number)
+ * @method static make(int|string $number)
+ * @method static from(int|string $number)
+ * @method static makeOrNull(int|string $number)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Primitive/Integer.php
+++ b/src/Collection/Primitive/Integer.php
@@ -24,9 +24,9 @@ use PHP\Math\BigNumber\BigNumber;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static make(int|string $number)
- * @method static from(int|string $number)
- * @method static makeOrNull(int|string $number)
+ * @method static static make(int|string $number)
+ * @method static static from(int|string $number)
+ * @method static static makeOrNull(int|string $number)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Primitive/Text.php
+++ b/src/Collection/Primitive/Text.php
@@ -24,8 +24,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string|Stringable $value)
- * @method static static from(string|Stringable $value)
+ * @method static make(string|Stringable $value)
+ * @method static from(string|Stringable $value)
+ * @method static makeOrNull(string|Stringable $value)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/Collection/Primitive/Text.php
+++ b/src/Collection/Primitive/Text.php
@@ -24,9 +24,9 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static make(string|Stringable $value)
- * @method static from(string|Stringable $value)
- * @method static makeOrNull(string|Stringable $value)
+ * @method static static make(string|Stringable $value)
+ * @method static static from(string|Stringable $value)
+ * @method static static makeOrNull(string|Stringable $value)
  *
  * @extends ValueObject<TKey, TValue>
  */

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -51,6 +51,18 @@ abstract class ValueObject implements Arrayable
     }
 
     /**
+     * Create a value object or return null.
+     *
+     * @param  mixed  $values
+     *
+     * @return static|null
+     */
+    public static function makeOrNull(mixed ...$values): static|null
+    {
+        return rescue(fn () => static::make(...$values), report: false);
+    }
+
+    /**
      * Check if objects are instances of same class
      * and share the same properties and values.
      *

--- a/tests/Unit/ValueObjectTest.php
+++ b/tests/Unit/ValueObjectTest.php
@@ -12,3 +12,11 @@ test('base value object is macroable', function () {
     $valueObject = new Text('Lorem ipsum');
     $this->assertSame(['Lorem ipsum'], $valueObject->collect()->toArray());
 });
+
+test('can use makeOrNull', function () {
+    $this->assertNull(Text::makeOrNull(''));
+    $this->assertNull(Text::makeOrNull('')?->value());
+
+    $this->assertEquals(Text::make('Lorem ipsum'), Text::makeOrNull('Lorem ipsum'));
+    $this->assertSame('Lorem ipsum', Text::makeOrNull('Lorem ipsum')->value());
+});


### PR DESCRIPTION
## About

If you want to have a value object with valid data, or `null` assigned to the property in case it fails, you can use `makeOrNull` method:

```php
// VO validation fails:

Uuid::makeOrNull('123'); // null
```