### PR TITLE
Add `Email` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ $classString = new ClassString('\Exception');
 $classString = ClassString::make('\Exception');
 $classString = ClassString::from('\Exception');
 
-$classString->value(); // '\Exception'
-(string) $classString; // '\Exception'
-$name->toArray();      // ['\Exception']
+$classString->value();   // '\Exception'
+(string) $classString;   // '\Exception'
+$classString->toArray(); // ['\Exception']
 
 $classString->classExists();     // true
 $classString->interfaceExists(); // false

--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ $classString->instantiateWith(['message' => 'My message.']); // Exception { #mes
 
 ---
 
+### Email
+```php
+$email = new Email('michael@laravel.software');
+$email = Email::make('michael@laravel.software');
+$email = Email::from('michael@laravel.software');
+
+$email->value();   // 'michael@laravel.software'
+(string) $email;   // 'michael@laravel.software'
+$email->toArray(); // ['michael@laravel.software']
+```
+
+---
+
 ### FullName
 ```php
 $name = new FullName(' Taylor   Otwell ');

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -16,7 +16,7 @@ use Illuminate\Validation\ValidationException;
 use MichaelRubel\ValueObjects\Collection\Primitive\Text;
 
 /**
- * "Email" object presenting a generic name.
+ * "Email" object that represents the email address.
  *
  * @author Michael Rubél <michael@laravel.software>
  *

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of michael-rubel/laravel-value-objects. (https://github.com/michael-rubel/laravel-value-objects)
+ *
+ * @link https://github.com/michael-rubel/laravel-value-objects for the canonical source repository
+ * @copyright Copyright (c) 2022 Michael Rubél. (https://github.com/michael-rubel/)
+ * @license https://raw.githubusercontent.com/michael-rubel/laravel-value-objects/main/LICENSE.md MIT
+ */
+
+namespace MichaelRubel\ValueObjects\Collection\Complex;
+
+use Illuminate\Support\Stringable;
+use Illuminate\Validation\Concerns\ValidatesAttributes;
+use Illuminate\Validation\ValidationException;
+use MichaelRubel\ValueObjects\Collection\Primitive\Text;
+
+/**
+ * "Email" object presenting a generic name.
+ *
+ * @author Michael Rubél <michael@laravel.software>
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @method static static make(string|Stringable $value)
+ * @method static static from(string|Stringable $value)
+ * @method static static makeOrNull(string|Stringable|null $value)
+ *
+ * @extends Text<TKey, TValue>
+ */
+class Email extends Text
+{
+    use ValidatesAttributes;
+
+    /**
+     * Create a new instance of the value object.
+     *
+     * @param  string|Stringable  $value
+     */
+    public function __construct(protected string|Stringable $value)
+    {
+        parent::__construct($this->value);
+
+        $this->validate();
+    }
+
+    /**
+     * Validate the email.
+     *
+     * @return void
+     */
+    protected function validate(): void
+    {
+        $toValidate = ['email', $this->value(), ['filter', 'dns']];
+
+        if (! $this->validateEmail(...$toValidate)) {
+            throw ValidationException::withMessages(['Your email is invalid.']);
+        }
+    }
+}

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -55,7 +55,7 @@ class Email extends Text
         $toValidate = ['email', $this->value(), $this->validationParameters()];
 
         if (! $this->validateEmail(...$toValidate)) {
-            throw ValidationException::withMessages(['Your email is invalid.']);
+            throw ValidationException::withMessages([__('Your email is invalid.')]);
         }
     }
 

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -52,10 +52,20 @@ class Email extends Text
      */
     protected function validate(): void
     {
-        $toValidate = ['email', $this->value(), ['filter', 'dns']];
+        $toValidate = ['email', $this->value(), $this->validationParameters()];
 
         if (! $this->validateEmail(...$toValidate)) {
             throw ValidationException::withMessages(['Your email is invalid.']);
         }
+    }
+
+    /**
+     * Define how you want to validate the email.
+     *
+     * @return array
+     */
+    protected function validationParameters(): array
+    {
+        return ['filter', 'spoof', 'dns'];
     }
 }

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -66,6 +66,6 @@ class Email extends Text
      */
     protected function validationParameters(): array
     {
-        return ['filter', 'spoof', 'dns'];
+        return ['filter', 'spoof'];
     }
 }

--- a/tests/Unit/Complex/EmailTest.php
+++ b/tests/Unit/Complex/EmailTest.php
@@ -23,12 +23,6 @@ test('email is wrong with at', function () {
     new Email('laravel@framework');
 });
 
-test('email fails when non-existing domain', function () {
-    $this->expectException(ValidationException::class);
-
-    new Email('test@non-existing.domain');
-});
-
 test('email cannot accept null', function () {
     $this->expectException(\TypeError::class);
 

--- a/tests/Unit/Complex/EmailTest.php
+++ b/tests/Unit/Complex/EmailTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Validation\ValidationException;
+use MichaelRubel\ValueObjects\Collection\Complex\Email;
+
+test('email is ok', function () {
+    $email = new Email('michael@laravel.software');
+
+    $this->assertSame('michael@laravel.software', $email->value());
+});
+
+test('email is wrong', function () {
+    $this->expectException(ValidationException::class);
+
+    new Email('123');
+});
+
+test('email is wrong with at', function () {
+    $this->expectException(ValidationException::class);
+
+    new Email('laravel@framework');
+});
+
+test('email fails when non-existing domain', function () {
+    $this->expectException(ValidationException::class);
+
+    new Email('test@non-existing.domain');
+});
+
+test('email cannot accept null', function () {
+    $this->expectException(\TypeError::class);
+
+    new Email(null);
+});
+
+test('email fails when no argument passed', function () {
+    $this->expectException(\TypeError::class);
+
+    new Email;
+});
+
+test('email fails when empty string passed', function () {
+    $this->expectException(ValidationException::class);
+
+    new Email('');
+});
+
+test('email is makeable', function () {
+    $valueObject = Email::make('michael@laravel.software');
+    $this->assertSame('michael@laravel.software', $valueObject->value());
+
+    $valueObject = Email::from('michael@laravel.software');
+    $this->assertSame('michael@laravel.software', $valueObject->value());
+});
+
+test('email is macroable', function () {
+    Email::macro('str', function () {
+        return str($this->value());
+    });
+
+    $valueObject = new Email('michael@laravel.software');
+
+    $this->assertTrue($valueObject->str()->is('michael@laravel.software'));
+});
+
+test('email is conditionable', function () {
+    $valueObject = new Email('michael@laravel.software');
+    $this->assertSame('michael@laravel.software', $valueObject->when(true)->value());
+    $this->assertSame($valueObject, $valueObject->when(false)->value());
+});
+
+test('email is arrayable', function () {
+    $array = (new Email('michael@laravel.software'))->toArray();
+    $this->assertSame(['michael@laravel.software'], $array);
+});
+
+test('email is stringable', function () {
+    $valueObject = new Email('michael@laravel.software');
+    $this->assertSame('michael@laravel.software', (string) $valueObject);
+});
+
+test('email accepts stringable', function () {
+    $valueObject = new Email(str('michael@laravel.software'));
+    $this->assertSame('michael@laravel.software', $valueObject->value());
+});
+
+test('email fails when empty stringable passed', function () {
+    $this->expectException(ValidationException::class);
+
+    new Email(str(''));
+});


### PR DESCRIPTION
## About

Adds `Email` object that extends from `Text` and contains email validation from `Illuminate/Validation` with filter and spoof checks.

```php
$email = new Email('michael@laravel.software');

$email->value();
```