### PR TITLE
Add `Phone` object

### DIFF
--- a/src/Collection/Complex/Phone.php
+++ b/src/Collection/Complex/Phone.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of michael-rubel/laravel-value-objects. (https://github.com/michael-rubel/laravel-value-objects)
+ *
+ * @link https://github.com/michael-rubel/laravel-value-objects for the canonical source repository
+ * @copyright Copyright (c) 2022 Michael Rubél. (https://github.com/michael-rubel/)
+ * @license https://raw.githubusercontent.com/michael-rubel/laravel-value-objects/main/LICENSE.md MIT
+ */
+
+namespace MichaelRubel\ValueObjects\Collection\Complex;
+
+use Illuminate\Support\Stringable;
+use Illuminate\Validation\ValidationException;
+use MichaelRubel\ValueObjects\Collection\Primitive\Text;
+
+/**
+ * "Phone" object that represents a telephone number.
+ *
+ * @author Michael Rubél <michael@laravel.software>
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @method static static make(string|Stringable $value)
+ * @method static static from(string|Stringable $value)
+ * @method static static makeOrNull(string|Stringable|null $value)
+ *
+ * @extends Text<TKey, TValue>
+ */
+class Phone extends Text
+{
+    /**
+     * Create a new instance of the value object.
+     *
+     * @param  string|Stringable  $value
+     */
+    public function __construct(protected string|Stringable $value)
+    {
+        parent::__construct($this->value);
+
+        $this->validate();
+    }
+
+    /**
+     * Get the sanitized phone number.
+     *
+     * @return string
+     */
+    public function sanitized(): string
+    {
+        return str($this->value())
+            ->squish()
+            ->replace(' ', '')
+            ->value();
+    }
+
+    /**
+     * Validate the email.
+     *
+     * @return void
+     */
+    protected function validate(): void
+    {
+        if (! preg_match('/^[0-9+ ]{7,16}$/', $this->value()) > 0) {
+            throw ValidationException::withMessages([__('Your phone number is invalid.')]);
+        }
+    }
+}

--- a/tests/Unit/Complex/PhoneTest.php
+++ b/tests/Unit/Complex/PhoneTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Validation\ValidationException;
+use MichaelRubel\ValueObjects\Collection\Complex\Phone;
+
+test('phone is ok', function () {
+    $phone = new Phone('+48 00 000 00 00');
+    $this->assertSame('+48 00 000 00 00', $phone->value());
+
+    $phone = new Phone('+48000000000');
+    $this->assertSame('+48000000000', $phone->value());
+
+    $phone = new Phone('000 000 000');
+    $this->assertSame('000 000 000', $phone->value());
+
+    $phone = new Phone('000000000');
+    $this->assertSame('000000000', $phone->value());
+});
+
+test('phone is sanitized', function () {
+    $phone = new Phone('+48 00 000 00 00');
+    $this->assertSame('+48000000000', $phone->sanitized());
+
+    $phone = new Phone('00 000 00 00');
+    $this->assertSame('000000000', $phone->sanitized());
+});
+
+test('phone is wrong', function () {
+    $this->expectException(ValidationException::class);
+
+    new Phone('123123');
+});
+
+test('phone cannot accept null', function () {
+    $this->expectException(\TypeError::class);
+
+    new Phone(null);
+});
+
+test('phone fails when no argument passed', function () {
+    $this->expectException(\TypeError::class);
+
+    new Phone;
+});
+
+test('phone fails when empty string passed', function () {
+    $this->expectException(ValidationException::class);
+
+    new Phone('');
+});
+
+test('phone is makeable', function () {
+    $valueObject = Phone::make('+48 00 000 00 00');
+    $this->assertSame('+48 00 000 00 00', $valueObject->value());
+
+    $valueObject = Phone::from('+48 00 000 00 00');
+    $this->assertSame('+48 00 000 00 00', $valueObject->value());
+});
+
+test('phone is macroable', function () {
+    Phone::macro('str', function () {
+        return str($this->value());
+    });
+
+    $valueObject = new Phone('+48 00 000 00 00');
+
+    $this->assertTrue($valueObject->str()->is('+48 00 000 00 00'));
+});
+
+test('phone is conditionable', function () {
+    $valueObject = new Phone('+48 00 000 00 00');
+    $this->assertSame('+48 00 000 00 00', $valueObject->when(true)->value());
+    $this->assertSame($valueObject, $valueObject->when(false)->value());
+});
+
+test('phone is arrayable', function () {
+    $array = (new Phone('+48 00 000 00 00'))->toArray();
+    $this->assertSame(['+48 00 000 00 00'], $array);
+});
+
+test('phone is stringable', function () {
+    $valueObject = new Phone('+48 00 000 00 00');
+    $this->assertSame('+48 00 000 00 00', (string) $valueObject);
+});
+
+test('phone accepts stringable', function () {
+    $valueObject = new Phone(str('+48 00 000 00 00'));
+    $this->assertSame('+48 00 000 00 00', $valueObject->value());
+});
+
+test('phone fails when empty stringable passed', function () {
+    $this->expectException(ValidationException::class);
+
+    new Phone(str(''));
+});
+
+test('phone is immutable', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new Phone('+48 00 000 00 00');
+    $this->assertSame('+48 00 000 00 00', $valueObject->value);
+    $valueObject->value = 'immutable';
+});


### PR DESCRIPTION
## About

Adds `Phone` object to hold the phone number. Validates numbers using basic regexp. Optionally, you can get a sanitized version 
 of your phone (without spaces).
 
 ```php
$phone = new Phone('+38 000 000 00 00');

$phone->value();     // '+38 000 000 00 00'
$phone->sanitized(); // '+380000000000'
```