### PR TITLE
Improve objects immutability

### DIFF
--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace MichaelRubel\ValueObjects\Collection\Complex;
 
 use Illuminate\Validation\ValidationException;
+use InvalidArgumentException;
 use MichaelRubel\ValueObjects\ValueObject;
 
 /**
@@ -32,12 +33,23 @@ use MichaelRubel\ValueObjects\ValueObject;
 class ClassString extends ValueObject
 {
     /**
+     * @var string
+     */
+    protected string $string;
+
+    /**
      * Create a new instance of the value object.
      *
      * @param  string  $string
      */
-    public function __construct(protected string $string)
+    public function __construct(string $string)
     {
+        if (isset($this->string)) {
+            throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
+        }
+
+        $this->string = $string;
+
         $this->validate();
     }
 

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -38,9 +38,9 @@ class Email extends Text
      *
      * @param  string|Stringable  $value
      */
-    public function __construct(protected string|Stringable $value)
+    public function __construct(string|Stringable $value)
     {
-        parent::__construct($this->value);
+        parent::__construct($value);
 
         $this->validate();
     }

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -32,7 +32,7 @@ use MichaelRubel\ValueObjects\ValueObject;
  *
  * @extends ValueObject<TKey, TValue>
  */
-class FullName extends ValueObject
+class FullName extends Name
 {
     /**
      * @var Collection<int, string>
@@ -44,11 +44,11 @@ class FullName extends ValueObject
      *
      * @param  string|Stringable  $value
      */
-    public function __construct(protected string|Stringable $value)
+    public function __construct(string|Stringable $value)
     {
-        $this->split();
-        $this->sanitize();
-        $this->validate();
+        static::beforeParentCalls(fn () => $this->split());
+
+        parent::__construct($value);
     }
 
     /**
@@ -79,16 +79,6 @@ class FullName extends ValueObject
     public function lastName(): string
     {
         return (string) $this->split->last();
-    }
-
-    /**
-     * Get the object value.
-     *
-     * @return string
-     */
-    public function value(): string
-    {
-        return (string) $this->value;
     }
 
     /**

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -16,7 +16,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
 use Illuminate\Validation\ValidationException;
 use MichaelRubel\Formatters\Collection\FullNameFormatter;
-use MichaelRubel\ValueObjects\ValueObject;
 
 /**
  * "FullName" object presenting a full name.
@@ -30,7 +29,7 @@ use MichaelRubel\ValueObjects\ValueObject;
  * @method static static from(string|Stringable $value)
  * @method static static makeOrNull(string|Stringable|null $value)
  *
- * @extends ValueObject<TKey, TValue>
+ * @extends Name<TKey, TValue>
  */
 class FullName extends Name
 {

--- a/src/Collection/Complex/Name.php
+++ b/src/Collection/Complex/Name.php
@@ -36,9 +36,9 @@ class Name extends Text
      *
      * @param  string|Stringable  $value
      */
-    public function __construct(protected string|Stringable $value)
+    public function __construct(string|Stringable $value)
     {
-        parent::__construct($this->value);
+        parent::__construct($value);
 
         $this->sanitize();
     }

--- a/src/Collection/Complex/Phone.php
+++ b/src/Collection/Complex/Phone.php
@@ -35,9 +35,9 @@ class Phone extends Text
      *
      * @param  string|Stringable  $value
      */
-    public function __construct(protected string|Stringable $value)
+    public function __construct(string|Stringable $value)
     {
-        parent::__construct($this->value);
+        parent::__construct($value);
 
         $this->validate();
         $this->trim();

--- a/src/Collection/Complex/Phone.php
+++ b/src/Collection/Complex/Phone.php
@@ -39,7 +39,6 @@ class Phone extends Text
     {
         parent::__construct($value);
 
-        $this->validate();
         $this->trim();
     }
 

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -51,7 +51,7 @@ class TaxNumber extends ValueObject
      */
     public function __construct(string $number, ?string $prefix = null)
     {
-        if (isset($this->number) || isset($this->prefix)) {
+        if (isset($this->number)) {
             throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
         }
 

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace MichaelRubel\ValueObjects\Collection\Complex;
 
 use Illuminate\Validation\ValidationException;
+use InvalidArgumentException;
 use MichaelRubel\Formatters\Collection\TaxNumberFormatter;
 use MichaelRubel\ValueObjects\ValueObject;
 
@@ -33,15 +34,30 @@ use MichaelRubel\ValueObjects\ValueObject;
 class TaxNumber extends ValueObject
 {
     /**
+     * @var string
+     */
+    protected string $number;
+
+    /**
+     * @var string|null
+     */
+    protected ?string $prefix = null;
+
+    /**
      * Create a new instance of the value object.
      *
      * @param  string  $number
      * @param  string|null  $prefix
      */
-    public function __construct(
-        protected string $number,
-        protected ?string $prefix = null,
-    ) {
+    public function __construct(string $number, ?string $prefix = null)
+    {
+        if (isset($this->number) || isset($this->prefix)) {
+            throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
+        }
+
+        $this->number = $number;
+        $this->prefix = $prefix;
+
         $this->validate();
         $this->sanitize();
 

--- a/src/Collection/Complex/Uuid.php
+++ b/src/Collection/Complex/Uuid.php
@@ -50,7 +50,7 @@ class Uuid extends ValueObject
      */
     public function __construct(string $value, ?string $name = null)
     {
-        if (isset($this->value) || isset($this->name)) {
+        if (isset($this->value)) {
             throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
         }
 

--- a/src/Collection/Complex/Uuid.php
+++ b/src/Collection/Complex/Uuid.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace MichaelRubel\ValueObjects\Collection\Complex;
 
 use Illuminate\Validation\ValidationException;
+use InvalidArgumentException;
 use MichaelRubel\ValueObjects\ValueObject;
 
 /**
@@ -32,15 +33,30 @@ use MichaelRubel\ValueObjects\ValueObject;
 class Uuid extends ValueObject
 {
     /**
+     * @var string
+     */
+    protected string $value;
+
+    /**
+     * @var string|null
+     */
+    protected ?string $name = null;
+
+    /**
      * Create a new instance of the value object.
      *
      * @param  string  $value
      * @param  string|null  $name
      */
-    public function __construct(
-        protected string $value,
-        protected ?string $name = null,
-    ) {
+    public function __construct(string $value, ?string $name = null)
+    {
+        if (isset($this->value) || isset($this->name)) {
+            throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
+        }
+
+        $this->value = $value;
+        $this->name  = $name;
+
         $this->validate();
     }
 

--- a/src/Collection/Primitive/Boolean.php
+++ b/src/Collection/Primitive/Boolean.php
@@ -32,6 +32,11 @@ use MichaelRubel\ValueObjects\ValueObject;
 class Boolean extends ValueObject
 {
     /**
+     * @var bool|int|string
+     */
+    protected bool|int|string $value;
+
+    /**
      * Allowed values that are treated as `true`.
      *
      * @var array
@@ -50,8 +55,14 @@ class Boolean extends ValueObject
      *
      * @param  bool|int|string  $value
      */
-    public function __construct(protected bool|int|string $value)
+    public function __construct(bool|int|string $value)
     {
+        if (isset($this->value)) {
+            throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
+        }
+
+        $this->value = $value;
+
         $this->value = match (true) {
             $this->isInTrueValues()  => true,
             $this->isInFalseValues() => false,

--- a/src/Collection/Primitive/Number.php
+++ b/src/Collection/Primitive/Number.php
@@ -41,23 +41,16 @@ class Number extends ValueObject
     protected BigNumber $bigNumber;
 
     /**
-     * @var int
-     */
-    protected int $scale = 2;
-
-    /**
      * Create a new instance of the value object.
      *
      * @param  int|string  $number
      * @param  int  $scale
      */
-    public function __construct(int|string $number, int $scale = 2)
+    public function __construct(int|string $number, protected int $scale = 2)
     {
         if (isset($this->bigNumber)) {
             throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
         }
-
-        $this->scale = $scale;
 
         $this->bigNumber = new BigNumber($this->sanitize($number), $this->scale);
     }

--- a/src/Collection/Primitive/Number.php
+++ b/src/Collection/Primitive/Number.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace MichaelRubel\ValueObjects\Collection\Primitive;
 
+use InvalidArgumentException;
 use MichaelRubel\ValueObjects\Concerns\SanitizesNumbers;
 use MichaelRubel\ValueObjects\ValueObject;
 use PHP\Math\BigNumber\BigNumber;
@@ -40,13 +41,24 @@ class Number extends ValueObject
     protected BigNumber $bigNumber;
 
     /**
+     * @var int
+     */
+    protected int $scale = 2;
+
+    /**
      * Create a new instance of the value object.
      *
      * @param  int|string  $number
      * @param  int  $scale
      */
-    public function __construct(int|string $number, protected int $scale = 2)
+    public function __construct(int|string $number, int $scale = 2)
     {
+        if (isset($this->bigNumber)) {
+            throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
+        }
+
+        $this->scale = $scale;
+
         $this->bigNumber = new BigNumber($this->sanitize($number), $this->scale);
     }
 

--- a/src/Collection/Primitive/Text.php
+++ b/src/Collection/Primitive/Text.php
@@ -33,12 +33,23 @@ use MichaelRubel\ValueObjects\ValueObject;
 class Text extends ValueObject
 {
     /**
+     * @var string|Stringable
+     */
+    protected string|Stringable $value;
+
+    /**
      * Create a new instance of the value object.
      *
      * @param  string|Stringable  $value
      */
-    public function __construct(protected string|Stringable $value)
+    public function __construct(string|Stringable $value)
     {
+        if (isset($this->value)) {
+            throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
+        }
+
+        $this->value = $value;
+
         $this->validate();
     }
 

--- a/src/Collection/Primitive/Text.php
+++ b/src/Collection/Primitive/Text.php
@@ -50,6 +50,10 @@ class Text extends ValueObject
 
         $this->value = $value;
 
+        if (isset($this->before)) {
+            ($this->before)();
+        }
+
         $this->validate();
     }
 

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -32,6 +32,8 @@ abstract class ValueObject implements Arrayable
     use Macroable, Conditionable;
 
     /**
+     * Immutability message.
+     *
      * @var string
      */
     public const IMMUTABLE_MESSAGE = 'Value objects are immutable, create a new object instead.';

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace MichaelRubel\ValueObjects;
 
+use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
@@ -37,6 +38,14 @@ abstract class ValueObject implements Arrayable
      * @var string
      */
     public const IMMUTABLE_MESSAGE = 'Value objects are immutable, create a new object instead.';
+
+    /**
+     * Callback to hook into parent construct
+     * before any other call is performed.
+     *
+     * @var Closure
+     */
+    protected Closure $before;
 
     /**
      * Get the object value.
@@ -104,6 +113,18 @@ abstract class ValueObject implements Arrayable
     public function notEquals(ValueObject $object): bool
     {
         return ! $this->equals($object);
+    }
+
+    /**
+     * Set the "before" callback.
+     *
+     * @param  Closure  $callback
+     *
+     * @return void
+     */
+    protected function beforeParentCalls(Closure $callback): void
+    {
+        $this->before = $callback;
     }
 
     /**

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -146,6 +146,6 @@ abstract class ValueObject implements Arrayable
      */
     public function __set(string $name, mixed $value): void
     {
-        throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
+        throw new InvalidArgumentException(__(static::IMMUTABLE_MESSAGE));
     }
 }

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -32,6 +32,11 @@ abstract class ValueObject implements Arrayable
     use Macroable, Conditionable;
 
     /**
+     * @var string
+     */
+    public const IMMUTABLE_MESSAGE = 'Value objects are immutable, create a new object instead.';
+
+    /**
      * Get the object value.
      *
      * @return mixed
@@ -141,6 +146,6 @@ abstract class ValueObject implements Arrayable
      */
     public function __set(string $name, mixed $value): void
     {
-        throw new InvalidArgumentException('Value objects are immutable, you cannot modify properties. Create a new object instead.');
+        throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
     }
 }

--- a/tests/Unit/Complex/ClassStringTest.php
+++ b/tests/Unit/Complex/ClassStringTest.php
@@ -100,9 +100,15 @@ test('class string is stringable', function () {
     $this->assertSame($valueObject->value(), (string) $valueObject);
 });
 
-test('class string is immutable', function () {
+test('class string has immutable properties', function () {
     $this->expectException(\InvalidArgumentException::class);
     $valueObject = new ClassString('\Exception');
     $this->assertSame('\Exception', $valueObject->string);
     $valueObject->classString = 'immutable';
+});
+
+test('class string has immutable constructor', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new ClassString('\Exception');
+    $valueObject->__construct('\Throwable');
 });

--- a/tests/Unit/Complex/EmailTest.php
+++ b/tests/Unit/Complex/EmailTest.php
@@ -86,9 +86,15 @@ test('email fails when empty stringable passed', function () {
     new Email(str(''));
 });
 
-test('email is immutable', function () {
+test('email has immutable properties', function () {
     $this->expectException(\InvalidArgumentException::class);
     $valueObject = new Email('contact@observer.name');
     $this->assertSame('contact@observer.name', $valueObject->value);
     $valueObject->value = 'immutable';
+});
+
+test('email has immutable constructor', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new Email('contact@observer.name');
+    $valueObject->__construct('contact@observer.com');
 });

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -115,9 +115,15 @@ test('full name fails when passed only first name', function () {
     new FullName('Name');
 });
 
-test('full name is immutable', function () {
+test('full name has immutable properties', function () {
     $this->expectException(\InvalidArgumentException::class);
     $valueObject = new FullName('Michael Rubél');
     $this->assertSame('Michael Rubél', $valueObject->value);
     $valueObject->full_name = 'immutable';
+});
+
+test('full name has immutable constructor', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new FullName('Michael Rubél');
+    $valueObject->__construct(' Michael Rubél ');
 });

--- a/tests/Unit/Complex/NameTest.php
+++ b/tests/Unit/Complex/NameTest.php
@@ -85,9 +85,15 @@ test('text fails when empty stringable passed', function () {
     new Name(str(''));
 });
 
-test('name is immutable', function () {
+test('name has immutable properties', function () {
     $this->expectException(\InvalidArgumentException::class);
     $valueObject = new Name('Lorem ipsum');
     $this->assertSame('Lorem ipsum', $valueObject->value);
     $valueObject->value = 'immutable';
+});
+
+test('name has immutable constructor', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new Name('Lorem ipsum');
+    $valueObject->__construct(' Lorem ipsum ');
 });

--- a/tests/Unit/Complex/PhoneTest.php
+++ b/tests/Unit/Complex/PhoneTest.php
@@ -131,3 +131,16 @@ test('phone is immutable', function () {
     $this->assertSame('+48 00 000 00 00', $valueObject->value);
     $valueObject->value = 'immutable';
 });
+
+test('phone has immutable properties', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new Phone('+48 00 000 00 00');
+    $this->assertSame('+48 00 000 00 00', $valueObject->value);
+    $valueObject->value = 'immutable';
+});
+
+test('phone has immutable constructor', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new Phone('+48 00 000 00 00');
+    $valueObject->__construct('+38 000 000 00 00');
+});

--- a/tests/Unit/Complex/TaxNumberTest.php
+++ b/tests/Unit/Complex/TaxNumberTest.php
@@ -167,9 +167,15 @@ test('tax number is stringable', function () {
     $this->assertSame($valueObject->value(), (string) $valueObject);
 });
 
-test('tax number is immutable', function () {
+test('tax number has immutable properties', function () {
     $this->expectException(\InvalidArgumentException::class);
     $valueObject = new TaxNumber('PL0123456789');
     $this->assertSame('0123456789', $valueObject->number);
     $valueObject->tax_number = 'immutable';
+});
+
+test('tax number has immutable constructor', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new TaxNumber('PL0123456789');
+    $valueObject->__construct(' PL0123456789 ');
 });

--- a/tests/Unit/Complex/UuidTest.php
+++ b/tests/Unit/Complex/UuidTest.php
@@ -83,10 +83,17 @@ test('uuid is stringable', function () {
     $this->assertSame($valueObject->value(), (string) $valueObject);
 });
 
-test('uuid value object is immutable', function () {
+test('uuid has immutable properties', function () {
     $this->expectException(\InvalidArgumentException::class);
     $uuid        = (string) Str::uuid();
     $valueObject = new Uuid($uuid);
     $this->assertSame($uuid, $valueObject->value);
     $valueObject->tax_number = 'immutable';
+});
+
+test('uuid has immutable constructor', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $uuid        = (string) Str::uuid();
+    $valueObject = new Uuid($uuid);
+    $valueObject->__construct($uuid, 'test');
 });

--- a/tests/Unit/Primitive/BooleanTest.php
+++ b/tests/Unit/Primitive/BooleanTest.php
@@ -140,9 +140,15 @@ test('boolean is stringable', function () {
     $this->assertSame('false', (string) $valueObject);
 });
 
-test('boolean is immutable', function () {
+test('boolean has immutable properties', function () {
     $this->expectException(\InvalidArgumentException::class);
     $valueObject = new Boolean('1');
     $this->assertTrue($valueObject->value);
     $valueObject->value = '0';
+});
+
+test('boolean has immutable constructor', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new Boolean('1');
+    $valueObject->__construct('false');
 });

--- a/tests/Unit/Primitive/NumberTest.php
+++ b/tests/Unit/Primitive/NumberTest.php
@@ -177,9 +177,15 @@ test('number is stringable', function () {
     $this->assertSame('1.80', (string) $valueObject);
 });
 
-test('number is immutable', function () {
+test('number has immutable properties', function () {
     $this->expectException(\InvalidArgumentException::class);
     $valueObject = new Number('1.2000');
     $this->assertEquals(new BigNumber('1.20', 2), $valueObject->bigNumber);
     $valueObject->bigNumber = new BigNumber('1.20');
+});
+
+test('number has immutable constructor', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new Number('1.2000');
+    $valueObject->__construct('1.5000');
 });

--- a/tests/Unit/Primitive/TextTest.php
+++ b/tests/Unit/Primitive/TextTest.php
@@ -116,9 +116,15 @@ test('text fails when empty stringable passed', function () {
     new Text(str(''));
 });
 
-test('text is immutable', function () {
+test('text has immutable properties', function () {
     $this->expectException(\InvalidArgumentException::class);
     $valueObject = new Text('Lorem ipsum');
     $this->assertSame('Lorem ipsum', $valueObject->value);
     $valueObject->value = 'test';
+});
+
+test('text has immutable constructor', function () {
+    $this->expectException(\InvalidArgumentException::class);
+    $valueObject = new Text('Lorem ipsum');
+    $valueObject->__construct(' Lorem ipsum ');
 });


### PR DESCRIPTION
- Resolves #13 

## About

- Makes it impossible to mutate internal value using the object's constructor;
- Adds `beforeParentCalls` method to make it possible to hook before parent calls.