### PR TITLE
Introduce break control in `FullName` 🧱

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ $name->fullName();  // 'Taylor Otwell'
 $name->firstName(); // 'Taylor'
 $name->lastName();  // 'Otwell'
 
-$name = new FullName('Richard Le Poidevin', parts: 2);
+$name = new FullName('Richard Le Poidevin', parts: 3);
 
 $name->toArray();
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ $name->fullName();  // 'Taylor Otwell'
 $name->firstName(); // 'Taylor'
 $name->lastName();  // 'Otwell'
 
-$name = new FullName('Richard Le Poidevin', spacing: 2);
+$name = new FullName('Richard Le Poidevin', parts: 2);
 
 $name->toArray();
 

--- a/README.md
+++ b/README.md
@@ -119,11 +119,20 @@ $name = FullName::from(' Taylor   Otwell ');
 
 $name->value();   // 'Taylor Otwell'
 (string) $name;   // 'Taylor Otwell'
-$name->toArray(); // ['fullName' => 'Taylor Otwell', 'firstName' => 'Taylor', 'lastName' => 'Otwell']
 
 $name->fullName();  // 'Taylor Otwell'
 $name->firstName(); // 'Taylor'
 $name->lastName();  // 'Otwell'
+
+$name = new FullName('Richard Le Poidevin', break: 2);
+
+$name->toArray();
+
+// array:3 [
+//  "fullName" => "Richard Le Poidevin"
+//  "firstName" => "Richard"
+//  "lastName" => "Le Poidevin"
+// ]
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ $name->fullName();  // 'Taylor Otwell'
 $name->firstName(); // 'Taylor'
 $name->lastName();  // 'Otwell'
 
-$name = new FullName('Richard Le Poidevin', break: 2);
+$name = new FullName('Richard Le Poidevin', spacing: 2);
 
 $name->toArray();
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,12 @@ $name->fullName();  // 'Taylor Otwell'
 $name->firstName(); // 'Taylor'
 $name->lastName();  // 'Otwell'
 
-$name = new FullName('Richard Le Poidevin', parts: 3);
+$name = 'Richard Le Poidevin';
+$parts = str_word_count($name);
 
-$name->toArray();
+$fullName = new FullName($name, $parts);
+
+$fullName->toArray();
 
 // array:3 [
 //  "fullName" => "Richard Le Poidevin"

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -42,8 +42,9 @@ class FullName extends Name
      * Create a new instance of the value object.
      *
      * @param  string|Stringable  $value
+     * @param  int  $break
      */
-    public function __construct(string|Stringable $value)
+    public function __construct(string|Stringable $value, protected int $break = -1)
     {
         static::beforeParentCalls(fn () => $this->split());
 
@@ -127,6 +128,6 @@ class FullName extends Name
      */
     protected function split(): void
     {
-        $this->split = str($this->value())->split('/\s/');
+        $this->split = str($this->value())->split('/\s/', $this->break);
     }
 }

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -25,9 +25,9 @@ use MichaelRubel\Formatters\Collection\FullNameFormatter;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string|Stringable $value, int $parts = -1)
- * @method static static from(string|Stringable $value, int $parts = -1)
- * @method static static makeOrNull(string|Stringable|null $value, int $parts = -1)
+ * @method static static make(string|Stringable $value, int $parts = 0)
+ * @method static static from(string|Stringable $value, int $parts = 0)
+ * @method static static makeOrNull(string|Stringable|null $value, int $parts = 0)
  *
  * @extends Name<TKey, TValue>
  */
@@ -44,7 +44,7 @@ class FullName extends Name
      * @param  string|Stringable  $value
      * @param  int  $parts
      */
-    public function __construct(string|Stringable $value, protected int $parts = -1)
+    public function __construct(string|Stringable $value, protected int $parts = 0)
     {
         static::beforeParentCalls(fn () => $this->split());
 
@@ -128,6 +128,6 @@ class FullName extends Name
      */
     protected function split(): void
     {
-        $this->split = str($this->value())->split('/\s/', $this->parts);
+        $this->split = str($this->value())->split('/\s/', $this->parts - 1);
     }
 }

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -25,9 +25,9 @@ use MichaelRubel\Formatters\Collection\FullNameFormatter;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string|Stringable $value, int $spacing = -1)
- * @method static static from(string|Stringable $value, int $spacing = -1)
- * @method static static makeOrNull(string|Stringable|null $value, int $spacing = -1)
+ * @method static static make(string|Stringable $value, int $parts = -1)
+ * @method static static from(string|Stringable $value, int $parts = -1)
+ * @method static static makeOrNull(string|Stringable|null $value, int $parts = -1)
  *
  * @extends Name<TKey, TValue>
  */
@@ -42,9 +42,9 @@ class FullName extends Name
      * Create a new instance of the value object.
      *
      * @param  string|Stringable  $value
-     * @param  int  $spacing
+     * @param  int  $parts
      */
-    public function __construct(string|Stringable $value, protected int $spacing = -1)
+    public function __construct(string|Stringable $value, protected int $parts = -1)
     {
         static::beforeParentCalls(fn () => $this->split());
 
@@ -128,6 +128,6 @@ class FullName extends Name
      */
     protected function split(): void
     {
-        $this->split = str($this->value())->split('/\s/', $this->spacing);
+        $this->split = str($this->value())->split('/\s/', $this->parts);
     }
 }

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -25,9 +25,9 @@ use MichaelRubel\Formatters\Collection\FullNameFormatter;
  * @template TKey of array-key
  * @template TValue
  *
- * @method static static make(string|Stringable $value)
- * @method static static from(string|Stringable $value)
- * @method static static makeOrNull(string|Stringable|null $value)
+ * @method static static make(string|Stringable $value, int $spacing = -1)
+ * @method static static from(string|Stringable $value, int $spacing = -1)
+ * @method static static makeOrNull(string|Stringable|null $value, int $spacing = -1)
  *
  * @extends Name<TKey, TValue>
  */
@@ -42,9 +42,9 @@ class FullName extends Name
      * Create a new instance of the value object.
      *
      * @param  string|Stringable  $value
-     * @param  int  $break
+     * @param  int  $spacing
      */
-    public function __construct(string|Stringable $value, protected int $break = -1)
+    public function __construct(string|Stringable $value, protected int $spacing = -1)
     {
         static::beforeParentCalls(fn () => $this->split());
 
@@ -128,6 +128,6 @@ class FullName extends Name
      */
     protected function split(): void
     {
-        $this->split = str($this->value())->split('/\s/', $this->break);
+        $this->split = str($this->value())->split('/\s/', $this->spacing);
     }
 }

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -100,6 +100,13 @@ test('full name is arrayable', function () {
         'firstName' => 'Michael',
         'lastName'  => 'Rubél',
     ], $valueObject->toArray());
+
+    $valueObject = new FullName('Richard Le Poidevin', break: 2);
+    $this->assertSame([
+        'fullName'  => 'Richard Le Poidevin',
+        'firstName' => 'Richard',
+        'lastName'  => 'Le Poidevin',
+    ], $valueObject->toArray());
 });
 
 test('full name is stringable', function () {

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -30,12 +30,15 @@ test('can get full name minus case', function () {
     $this->assertSame('Nowak-Kowalska', $name->lastName());
 });
 
-test('can get full name space case', function () {
-    $name = new FullName('Alicja', 'Bachleda Curuś');
-
+test('can get full name when space case', function () {
+    $name = new FullName('Alicja Bachleda Curuś', break: 2);
     $this->assertSame('Alicja', $name->firstName());
     $this->assertSame('Bachleda Curuś', $name->lastName());
-})->skip('edge case with spaces in last name');
+
+    $name = new FullName('Richard Le Poidevin', break: 2);
+    $this->assertSame('Richard', $name->firstName());
+    $this->assertSame('Le Poidevin', $name->lastName());
+});
 
 test('can get full name with name in between', function () {
     $name = new FullName('Anna Ewa Kowalska');

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -31,11 +31,11 @@ test('can get full name minus case', function () {
 });
 
 test('can get full name when space case', function () {
-    $name = new FullName('Alicja Bachleda Curuś', spacing: 2);
+    $name = new FullName('Alicja Bachleda Curuś', parts: 2);
     $this->assertSame('Alicja', $name->firstName());
     $this->assertSame('Bachleda Curuś', $name->lastName());
 
-    $name = new FullName('Richard Le Poidevin', spacing: 2);
+    $name = new FullName('Richard Le Poidevin', parts: 2);
     $this->assertSame('Richard', $name->firstName());
     $this->assertSame('Le Poidevin', $name->lastName());
 });
@@ -101,7 +101,7 @@ test('full name is arrayable', function () {
         'lastName'  => 'Rubél',
     ], $valueObject->toArray());
 
-    $valueObject = new FullName('Richard Le Poidevin', spacing: 2);
+    $valueObject = new FullName('Richard Le Poidevin', parts: 2);
     $this->assertSame([
         'fullName'  => 'Richard Le Poidevin',
         'firstName' => 'Richard',

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -31,11 +31,11 @@ test('can get full name minus case', function () {
 });
 
 test('can get full name when space case', function () {
-    $name = new FullName('Alicja Bachleda Curuś', break: 2);
+    $name = new FullName('Alicja Bachleda Curuś', spacing: 2);
     $this->assertSame('Alicja', $name->firstName());
     $this->assertSame('Bachleda Curuś', $name->lastName());
 
-    $name = new FullName('Richard Le Poidevin', break: 2);
+    $name = new FullName('Richard Le Poidevin', spacing: 2);
     $this->assertSame('Richard', $name->firstName());
     $this->assertSame('Le Poidevin', $name->lastName());
 });
@@ -101,7 +101,7 @@ test('full name is arrayable', function () {
         'lastName'  => 'Rubél',
     ], $valueObject->toArray());
 
-    $valueObject = new FullName('Richard Le Poidevin', break: 2);
+    $valueObject = new FullName('Richard Le Poidevin', spacing: 2);
     $this->assertSame([
         'fullName'  => 'Richard Le Poidevin',
         'firstName' => 'Richard',

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -30,14 +30,10 @@ test('can get full name minus case', function () {
     $this->assertSame('Nowak-Kowalska', $name->lastName());
 });
 
-test('can get full name when space case', function () {
-    $name = new FullName('Alicja Bachleda Curuś', parts: 2);
+test('full name with break control', function () {
+    $name = new FullName('Alicja Bachleda Curuś', parts: 3);
     $this->assertSame('Alicja', $name->firstName());
     $this->assertSame('Bachleda Curuś', $name->lastName());
-
-    $name = new FullName('Richard Le Poidevin', parts: 2);
-    $this->assertSame('Richard', $name->firstName());
-    $this->assertSame('Le Poidevin', $name->lastName());
 });
 
 test('can get full name with name in between', function () {
@@ -45,6 +41,13 @@ test('can get full name with name in between', function () {
 
     $this->assertSame('Anna', $name->firstName());
     $this->assertSame('Kowalska', $name->lastName());
+});
+
+test('can break control using word count', function () {
+    $name = 'Richard Le Poidevin';
+    $name = new FullName($name, str_word_count($name));
+    $this->assertSame('Richard', $name->firstName());
+    $this->assertSame('Le Poidevin', $name->lastName());
 });
 
 test('can get cast to string', function () {
@@ -101,7 +104,7 @@ test('full name is arrayable', function () {
         'lastName'  => 'Rubél',
     ], $valueObject->toArray());
 
-    $valueObject = new FullName('Richard Le Poidevin', parts: 2);
+    $valueObject = new FullName('Richard Le Poidevin', parts: 3);
     $this->assertSame([
         'fullName'  => 'Richard Le Poidevin',
         'firstName' => 'Richard',


### PR DESCRIPTION
- Resolves #11 

## About

Adds an additional parameter to `FullName` object to let the developer control how the split breaks your internal value. This way we can solve issues like the one described in #11.

---