### PR TITLE
Add `domain` and `username` methods to `Email`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $email = Email::from('michael@laravel.software');
 
 $email->value();   // 'michael@laravel.software'
 (string) $email;   // 'michael@laravel.software'
-$email->toArray(); // ['michael@laravel.software']
+$email->toArray(); // ['email' => 'michael@laravel.software', 'username' => 'michael', 'domain' => 'laravel.software']
 ```
 
 ---

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -35,7 +35,7 @@ class Email extends Text
     use ValidatesAttributes;
 
     /**
-     * @var Collection
+     * @var Collection<int, string>
      */
     protected Collection $split;
 
@@ -57,7 +57,7 @@ class Email extends Text
      */
     public function username(): string
     {
-        return $this->split->first();
+        return (string) $this->split->first();
     }
 
     /**
@@ -65,7 +65,7 @@ class Email extends Text
      */
     public function domain(): string
     {
-        return $this->split->last();
+        return (string) $this->split->last();
     }
 
     /**

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -69,6 +69,20 @@ class Email extends Text
     }
 
     /**
+     * Get an array representation of the value object.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'email'    => $this->value(),
+            'username' => $this->username(),
+            'domain'   => $this->domain(),
+        ];
+    }
+
+    /**
      * Validate the email.
      *
      * @return void

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -10,6 +10,7 @@
 
 namespace MichaelRubel\ValueObjects\Collection\Complex;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
 use Illuminate\Validation\Concerns\ValidatesAttributes;
 use Illuminate\Validation\ValidationException;
@@ -34,6 +35,11 @@ class Email extends Text
     use ValidatesAttributes;
 
     /**
+     * @var Collection
+     */
+    protected Collection $split;
+
+    /**
      * Create a new instance of the value object.
      *
      * @param  string|Stringable  $value
@@ -43,6 +49,23 @@ class Email extends Text
         parent::__construct($value);
 
         $this->validate();
+        $this->split();
+    }
+
+    /**
+     * @return string
+     */
+    public function username(): string
+    {
+        return $this->split->first();
+    }
+
+    /**
+     * @return string
+     */
+    public function domain(): string
+    {
+        return $this->split->last();
     }
 
     /**
@@ -67,5 +90,15 @@ class Email extends Text
     protected function validationParameters(): array
     {
         return ['filter', 'spoof'];
+    }
+
+    /**
+     * Split the value by at symbol.
+     *
+     * @return void
+     */
+    protected function split(): void
+    {
+        $this->split = str($this->value())->split('/@/');
     }
 }

--- a/tests/Unit/Complex/EmailTest.php
+++ b/tests/Unit/Complex/EmailTest.php
@@ -11,6 +11,18 @@ test('email is ok', function () {
     $this->assertSame('michael@laravel.software', $email->value());
 });
 
+test('email has username', function () {
+    $email = new Email('michael@laravel.software');
+
+    $this->assertSame('michael', $email->username());
+});
+
+test('email has domain', function () {
+    $email = new Email('michael@laravel.software');
+
+    $this->assertSame('laravel.software', $email->domain());
+});
+
 test('email is wrong', function () {
     $this->expectException(ValidationException::class);
 

--- a/tests/Unit/Complex/EmailTest.php
+++ b/tests/Unit/Complex/EmailTest.php
@@ -79,7 +79,11 @@ test('email is conditionable', function () {
 
 test('email is arrayable', function () {
     $array = (new Email('michael@laravel.software'))->toArray();
-    $this->assertSame(['michael@laravel.software'], $array);
+    $this->assertSame([
+        'email'    => 'michael@laravel.software',
+        'username' => 'michael',
+        'domain'   => 'laravel.software',
+    ], $array);
 });
 
 test('email is stringable', function () {


### PR DESCRIPTION
## About

Adds handy extraction of the username and domain parts from the email.

```php
$email = new Email('michael@laravel.software');

$email->username(); // 'michael'
$email->domain();   // 'laravel.software'
$email->toArray();  // ['email' => 'michael@laravel.software', 'username' => 'michael', 'domain' => 'laravel.software']
```

---