### PR TITLE
Remove unnecessary methods from Email class

### DIFF
--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -11,8 +11,8 @@
 namespace MichaelRubel\ValueObjects\Collection\Complex;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Stringable;
-use Illuminate\Validation\Concerns\ValidatesAttributes;
 use Illuminate\Validation\ValidationException;
 use MichaelRubel\ValueObjects\Collection\Primitive\Text;
 
@@ -87,19 +87,30 @@ class Email extends Text
      */
     protected function validate(): void
     {
-        $toValidate = ['email', $this->value(), $this->validationParameters()];
-        $validator = new class
-        {
-            use ValidatesAttributes;
-        };
+        $validator = Validator::make(
+            ['email' => $this->value()],
+            ['email' => $this->validationRules()],
+        );
 
-        if (!$validator->validateEmail(...$toValidate)) {
+        if ($validator->fails()) {
             throw ValidationException::withMessages([__('Your email is invalid.')]);
         }
     }
 
     /**
+     * Define the rules for email validator.
+     *
+     * @return array
+     */
+    protected function validationRules(): array
+    {
+        return ['required', 'email:' . implode(',', $this->validationParameters())];
+    }
+
+    /**
      * Define how you want to validate the email.
+     *
+     * @deprecated
      *
      * @return array
      */

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -32,8 +32,6 @@ use MichaelRubel\ValueObjects\Collection\Primitive\Text;
  */
 class Email extends Text
 {
-    use ValidatesAttributes;
-
     /**
      * @var Collection<int, string>
      */
@@ -90,8 +88,12 @@ class Email extends Text
     protected function validate(): void
     {
         $toValidate = ['email', $this->value(), $this->validationParameters()];
+        $validator = new class
+        {
+            use ValidatesAttributes;
+        };
 
-        if (! $this->validateEmail(...$toValidate)) {
+        if (!$validator->validateEmail(...$toValidate)) {
             throw ValidationException::withMessages([__('Your email is invalid.')]);
         }
     }


### PR DESCRIPTION
The Email class currently does more than handling email logic such as validating active urls, validating alphabetic characters, date validation, file validation, image validation and many other public method from the ValidatesAttributes trait which has no meaning to the Email value object.