### PR TITLE
Allow passing formatted value in `Number`

### DIFF
--- a/src/Concerns/SanitizesNumbers.php
+++ b/src/Concerns/SanitizesNumbers.php
@@ -13,8 +13,19 @@ trait SanitizesNumbers
      */
     public function sanitize(int|string|null $number): string
     {
-        return str($number)
-            ->replace([',', ' '], ['.', ''])
-            ->value();
+        $number = str($number)->replace(',', '.');
+
+        $dots = $number->substrCount('.');
+
+        if (1 < $dots) {
+            $number = $number
+                ->replaceLast('.', ',')
+                ->replace('.', '')
+                ->replaceLast(',', '.');
+        }
+
+        return $number
+            ->replaceMatches('/[^0-9.]/', '')
+            ->toString();
     }
 }

--- a/tests/Unit/Primitive/NumberTest.php
+++ b/tests/Unit/Primitive/NumberTest.php
@@ -74,6 +74,20 @@ test('number accepts formatted value', function () {
     assertSame('1230.00', $valueObject->value());
     $valueObject = new Number('123 123 123,55');
     assertSame('123123123.55', $valueObject->value());
+
+    // Mixed convention:
+    $valueObject = new Number('1 230,');
+    assertSame('1230.00', $valueObject->value());
+    $valueObject = new Number(',00');
+    assertSame('0.00', $valueObject->value());
+    $valueObject = new Number('.00');
+    assertSame('0.00', $valueObject->value());
+    $valueObject = new Number('123.123 123,55');
+    assertSame('123123123.55', $valueObject->value());
+    $valueObject = new Number('123,123.123,55');
+    assertSame('123123123.55', $valueObject->value());
+    $valueObject = new Number('123	123 123,55');
+    assertSame('123123123.55', $valueObject->value());
 });
 
 test('number fails when no argument passed', function () {

--- a/tests/Unit/Primitive/NumberTest.php
+++ b/tests/Unit/Primitive/NumberTest.php
@@ -38,6 +38,44 @@ test('number can accept string', function () {
     $this->assertSame('100000.000', $valueObject->value());
 });
 
+test('number accepts formatted value', function () {
+    // Only commas:
+    $valueObject = new Number('1,230,00');
+    assertSame('1230.00', $valueObject->value());
+    $valueObject = new Number('123,123,123,5555', scale: 3);
+    assertSame('123123123.555', $valueObject->value());
+
+    // Only dots:
+    $valueObject = new Number('1.230.00');
+    assertSame('1230.00', $valueObject->value());
+    $valueObject = new Number('123.123.123.555');
+    assertSame('123123123.55', $valueObject->value());
+
+    // Dot-comma convention:
+    $valueObject = new Number('1.230,00');
+    assertSame('1230.00', $valueObject->value());
+    $valueObject = new Number('123.123.123,556', scale: 3);
+    assertSame('123123123.556', $valueObject->value());
+
+    // Comma-dot convention:
+    $valueObject = new Number('1,230.00');
+    assertSame('1230.00', $valueObject->value());
+    $valueObject = new Number('123,123,123.555');
+    assertSame('123123123.55', $valueObject->value());
+
+    // Space-dot convention:
+    $valueObject = new Number('1 230.00');
+    assertSame('1230.00', $valueObject->value());
+    $valueObject = new Number('123 123 123.55');
+    assertSame('123123123.55', $valueObject->value());
+
+    // Space-comma convention:
+    $valueObject = new Number('1 230,00');
+    assertSame('1230.00', $valueObject->value());
+    $valueObject = new Number('123 123 123,55');
+    assertSame('123123123.55', $valueObject->value());
+});
+
 test('number fails when no argument passed', function () {
     $this->expectException(\TypeError::class);
 


### PR DESCRIPTION
## About

This PR adds value sanitization to accept a locale-formatted number in `Number` object.

```php
$number = new Number('1 230,00');

$number->value(); // 1230.00
```