### PR TITLE
Add `toString` convenience method

### DIFF
--- a/src/Collection/Primitive/Boolean.php
+++ b/src/Collection/Primitive/Boolean.php
@@ -105,8 +105,18 @@ class Boolean extends ValueObject
      *
      * @return string
      */
-    public function __toString(): string
+    public function toString(): string
     {
         return ! empty($this->value()) ? 'true' : 'false';
+    }
+
+    /**
+     * Get string representation of the value object.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->toString();
     }
 }

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -116,9 +116,19 @@ abstract class ValueObject implements Arrayable, Immutable
      *
      * @return string
      */
-    public function __toString(): string
+    public function toString(): string
     {
         return (string) $this->value();
+    }
+
+    /**
+     * Get string representation of the value object.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->toString();
     }
 
     /**

--- a/tests/Unit/Complex/ClassStringTest.php
+++ b/tests/Unit/Complex/ClassStringTest.php
@@ -98,6 +98,8 @@ test('class string is arrayable', function () {
 test('class string is stringable', function () {
     $valueObject = new ClassString('Throwable');
     $this->assertSame($valueObject->value(), (string) $valueObject);
+    $valueObject = new ClassString('Throwable');
+    $this->assertSame($valueObject->value(), $valueObject->toString());
 });
 
 test('class string has immutable properties', function () {

--- a/tests/Unit/Complex/EmailTest.php
+++ b/tests/Unit/Complex/EmailTest.php
@@ -89,6 +89,9 @@ test('email is arrayable', function () {
 test('email is stringable', function () {
     $valueObject = new Email('michael@laravel.software');
     $this->assertSame('michael@laravel.software', (string) $valueObject);
+
+    $valueObject = new Email('michael@laravel.software');
+    $this->assertSame('michael@laravel.software', $valueObject->toString());
 });
 
 test('email accepts stringable', function () {

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -52,8 +52,10 @@ test('can break control using word count', function () {
 
 test('can get cast to string', function () {
     $name = new FullName('Michael Rubél');
-
     $this->assertSame('Michael Rubél', (string) $name);
+
+    $name = new FullName('Michael Rubél');
+    $this->assertSame('Michael Rubél', $name->toString());
 });
 
 test('cannot pass empty string', function () {

--- a/tests/Unit/Complex/NameTest.php
+++ b/tests/Unit/Complex/NameTest.php
@@ -72,6 +72,9 @@ test('text is arrayable', function () {
 test('text is stringable', function () {
     $valueObject = new Name('Lorem ipsum');
     $this->assertSame('Lorem ipsum', (string) $valueObject);
+
+    $valueObject = new Name('Lorem ipsum');
+    $this->assertSame('Lorem ipsum', $valueObject->toString());
 });
 
 test('text accepts stringable', function () {

--- a/tests/Unit/Complex/PhoneTest.php
+++ b/tests/Unit/Complex/PhoneTest.php
@@ -113,6 +113,9 @@ test('phone is arrayable', function () {
 test('phone is stringable', function () {
     $valueObject = new Phone('+48 00 000 00 00');
     $this->assertSame('+48 00 000 00 00', (string) $valueObject);
+
+    $valueObject = new Phone('+48 00 000 00 00');
+    $this->assertSame('+48 00 000 00 00', $valueObject->toString());
 });
 
 test('phone accepts stringable', function () {

--- a/tests/Unit/Complex/TaxNumberTest.php
+++ b/tests/Unit/Complex/TaxNumberTest.php
@@ -165,6 +165,9 @@ test('tax number is arrayable', function () {
 test('tax number is stringable', function () {
     $valueObject = new TaxNumber('PL0123456789');
     $this->assertSame($valueObject->value(), (string) $valueObject);
+
+    $valueObject = new TaxNumber('PL0123456789');
+    $this->assertSame($valueObject->value(), $valueObject->toString());
 });
 
 test('tax number has immutable properties', function () {

--- a/tests/Unit/Complex/UuidTest.php
+++ b/tests/Unit/Complex/UuidTest.php
@@ -78,9 +78,13 @@ test('uuid is arrayable', function () {
 });
 
 test('uuid is stringable', function () {
-    $uuid        = (string) Str::uuid();
+    $uuid = (string) Str::uuid();
+
     $valueObject = new Uuid($uuid);
     $this->assertSame($valueObject->value(), (string) $valueObject);
+
+    $valueObject = new Uuid($uuid);
+    $this->assertSame($valueObject->value(), $valueObject->toString());
 });
 
 test('uuid has immutable properties', function () {

--- a/tests/Unit/Primitive/BooleanTest.php
+++ b/tests/Unit/Primitive/BooleanTest.php
@@ -137,7 +137,7 @@ test('boolean is stringable', function () {
     $valueObject = new Boolean('true');
     $this->assertSame('true', (string) $valueObject);
     $valueObject = new Boolean('false');
-    $this->assertSame('false', (string) $valueObject);
+    $this->assertSame('false', $valueObject->toString());
 });
 
 test('boolean has immutable properties', function () {

--- a/tests/Unit/Primitive/NumberTest.php
+++ b/tests/Unit/Primitive/NumberTest.php
@@ -227,6 +227,8 @@ test('number is stringable', function () {
     $this->assertSame('1.70', (string) $valueObject);
     $valueObject = new Number('1.8');
     $this->assertSame('1.80', (string) $valueObject);
+    $valueObject = new Number('1230.00');
+    $this->assertSame('1230.00', $valueObject->toString());
 });
 
 test('number has immutable properties', function () {

--- a/tests/Unit/Primitive/TextTest.php
+++ b/tests/Unit/Primitive/TextTest.php
@@ -103,6 +103,8 @@ test('text is stringable', function () {
     $this->assertSame('1.7', (string) $valueObject);
     $valueObject = new Text('1.8');
     $this->assertSame('1.8', (string) $valueObject);
+    $valueObject = new Text('Lorem ipsum');
+    $this->assertSame('Lorem ipsum', $valueObject->toString());
 });
 
 test('text accepts stringable', function () {


### PR DESCRIPTION
## About

As we have the toArray method in every value object, it's also nice to have a toString method to be able to get the string representation of the object without using a native (string) cast.

```php
$bool = new Boolean(1);

$bool->toString(); // 'true'
```