### PR TITLE
Add additional values in `Boolean` 🔧

### DIFF
--- a/src/Collection/Primitive/Boolean.php
+++ b/src/Collection/Primitive/Boolean.php
@@ -48,7 +48,7 @@ class Boolean extends ValueObject
      *
      * @var array
      */
-    protected array $falseValues = ['0', 'false', 'False', 'FALSE', 0, false];
+    protected array $falseValues = ['0', 'false', 'False', 'FALSE', 0, false, 'off', 'no'];
 
     /**
      * Create a new instance of the value object.

--- a/src/Collection/Primitive/Boolean.php
+++ b/src/Collection/Primitive/Boolean.php
@@ -41,7 +41,7 @@ class Boolean extends ValueObject
      *
      * @var array
      */
-    protected array $trueValues = ['1', 'true', 'True', 'TRUE', 1, true];
+    protected array $trueValues = ['1', 'true', 'True', 'TRUE', 1, true, 'on', 'yes'];
 
     /**
      * Allowed values that are treated as `false`.

--- a/tests/Unit/Primitive/BooleanTest.php
+++ b/tests/Unit/Primitive/BooleanTest.php
@@ -23,6 +23,10 @@ test('boolean can accept boolean strings', function () {
     $this->assertFalse($valueObject->value());
     $valueObject = new Boolean('False');
     $this->assertFalse($valueObject->value());
+    $valueObject = new Boolean('off');
+    $this->assertFalse($valueObject->value());
+    $valueObject = new Boolean('no');
+    $this->assertFalse($valueObject->value());
     $valueObject = new Boolean('FALSE');
     $this->assertFalse($valueObject->value());
     $valueObject = new Boolean('true');
@@ -104,7 +108,7 @@ test('boolean is macroable', function () {
         '1', 'true', 'True', 'TRUE', 1, true, 'on', 'yes'
     ], $valueObject->getPositiveValues());
     $this->assertSame([
-        '0', 'false', 'False', 'FALSE', 0, false,
+        '0', 'false', 'False', 'FALSE', 0, false, 'off', 'no'
     ], $valueObject->getNegativeValues());
 });
 

--- a/tests/Unit/Primitive/BooleanTest.php
+++ b/tests/Unit/Primitive/BooleanTest.php
@@ -105,10 +105,10 @@ test('boolean is macroable', function () {
     Boolean::macro('getNegativeValues', fn () => $this->falseValues);
     $valueObject = new Boolean(1);
     $this->assertSame([
-        '1', 'true', 'True', 'TRUE', 1, true, 'on', 'yes'
+        '1', 'true', 'True', 'TRUE', 1, true, 'on', 'yes',
     ], $valueObject->getPositiveValues());
     $this->assertSame([
-        '0', 'false', 'False', 'FALSE', 0, false, 'off', 'no'
+        '0', 'false', 'False', 'FALSE', 0, false, 'off', 'no',
     ], $valueObject->getNegativeValues());
 });
 

--- a/tests/Unit/Primitive/BooleanTest.php
+++ b/tests/Unit/Primitive/BooleanTest.php
@@ -31,6 +31,10 @@ test('boolean can accept boolean strings', function () {
     $this->assertTrue($valueObject->value());
     $valueObject = new Boolean('TRUE');
     $this->assertTrue($valueObject->value());
+    $valueObject = new Boolean('on');
+    $this->assertTrue($valueObject->value());
+    $valueObject = new Boolean('yes');
+    $this->assertTrue($valueObject->value());
 });
 
 test('boolean can accept native booleans', function () {
@@ -97,7 +101,7 @@ test('boolean is macroable', function () {
     Boolean::macro('getNegativeValues', fn () => $this->falseValues);
     $valueObject = new Boolean(1);
     $this->assertSame([
-        '1', 'true', 'True', 'TRUE', 1, true,
+        '1', 'true', 'True', 'TRUE', 1, true, 'on', 'yes'
     ], $valueObject->getPositiveValues());
     $this->assertSame([
         '0', 'false', 'False', 'FALSE', 0, false,


### PR DESCRIPTION
## About

This PR allows "on", "yes", "off", and "no" values in the `Boolean` object by default.

The changes are marked to ship in the major release as these are breaking changes.

---