### PR TITLE
Uppercase only first letter of each word in `FullName` object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/contracts": "^9.7",
-        "michael-rubel/laravel-formatters": "^6.3|^7.0",
+        "michael-rubel/laravel-formatters": "^6.3|^7.0.4",
         "phpmath/bignumber": "^1.2",
         "spatie/laravel-package-tools": "^1.12"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/contracts": "^9.7",
-        "michael-rubel/laravel-formatters": "^6.3|^7.0.4",
+        "michael-rubel/laravel-formatters": "^7.0.4",
         "phpmath/bignumber": "^1.2",
         "spatie/laravel-package-tools": "^1.12"
     },

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -51,6 +51,19 @@ test('can break control using word count', function () {
     $this->assertSame('Le Poidevin', $name->lastName());
 });
 
+test('full name covnerts the first letter of each word to uppercase', function ($input, $result) {
+    $name = new FullName($input);
+    $this->assertSame($result, $name->fullName());
+})->with([
+    ['michael mcKenzie', 'Michael McKenzie'],
+    ['michael McKenzie', 'Michael McKenzie'],
+    ['Michael mcKenzie', 'Michael McKenzie'],
+    ['Michael McKenzie', 'Michael McKenzie'],
+    ['michael mckenzie', 'Michael Mckenzie'],
+    ['michael mc-kenzie', 'Michael Mc-kenzie'],
+    [' michael mc-Kenzie ', 'Michael Mc-Kenzie'],
+]);
+
 test('can get cast to string', function () {
     $name = new FullName('Michael Rubél');
     $this->assertSame('Michael Rubél', (string) $name);


### PR DESCRIPTION
## About

This PR fixes the formatting behavior in `FullName` object.
There was a lack of coverage for names like `McKenzie`.

We're now converting the first letter of each word instead of doing a regular `Title Case`.

---