### PR TITLE
Remove `translator` dependency and require `illuminate/validation`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/contracts": "^9.33|^10.0",
+        "illuminate/validation": "^9.33|^10.0",
         "michael-rubel/laravel-formatters": "^7.0.6",
         "phpmath/bignumber": "^1.2",
         "spatie/laravel-package-tools": "^1.12"

--- a/src/Artisan/stubs/value-object.stub
+++ b/src/Artisan/stubs/value-object.stub
@@ -68,7 +68,7 @@ class {{ class }} extends ValueObject
         // TODO: Implement validate() method.
 
         if (empty($this->value())) {
-            throw ValidationException::withMessages([__('Value of {{ class }} cannot be empty.')]);
+            throw ValidationException::withMessages(['Value of {{ class }} cannot be empty.']);
         }
     }
 }

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -115,7 +115,7 @@ class ClassString extends ValueObject
     protected function validate(): void
     {
         if (empty($this->value())) {
-            throw ValidationException::withMessages([__('Class string cannot be empty.')]);
+            throw ValidationException::withMessages(['Class string cannot be empty.']);
         }
     }
 }

--- a/src/Collection/Complex/Email.php
+++ b/src/Collection/Complex/Email.php
@@ -92,7 +92,7 @@ class Email extends Text
         );
 
         if ($validator->fails()) {
-            throw ValidationException::withMessages([__('Your email is invalid.')]);
+            throw ValidationException::withMessages(['Your email is invalid.']);
         }
     }
 

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -103,11 +103,11 @@ class FullName extends Name
     protected function validate(): void
     {
         if (empty($this->value())) {
-            throw ValidationException::withMessages([__('Full name cannot be empty.')]);
+            throw ValidationException::withMessages(['Full name cannot be empty.']);
         }
 
         if (count($this->split) < 2) {
-            throw ValidationException::withMessages([__('Full name should have a first name and last name.')]);
+            throw ValidationException::withMessages(['Full name should have a first name and last name.']);
         }
     }
 

--- a/src/Collection/Complex/Phone.php
+++ b/src/Collection/Complex/Phone.php
@@ -63,7 +63,7 @@ class Phone extends Text
     protected function validate(): void
     {
         if (! preg_match('/^[+]?[0-9 ]{5,15}$/', $this->sanitized())) {
-            throw ValidationException::withMessages([__('Your phone number is invalid.')]);
+            throw ValidationException::withMessages(['Your phone number is invalid.']);
         }
     }
 

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -142,7 +142,7 @@ class TaxNumber extends ValueObject
     protected function validate(): void
     {
         if (empty($this->value())) {
-            throw ValidationException::withMessages([__('Tax number cannot be empty.')]);
+            throw ValidationException::withMessages(['Tax number cannot be empty.']);
         }
     }
 

--- a/src/Collection/Complex/Url.php
+++ b/src/Collection/Complex/Url.php
@@ -49,7 +49,7 @@ class Url extends Text
         );
 
         if ($validator->fails()) {
-            throw ValidationException::withMessages([__('Your URL is invalid.')]);
+            throw ValidationException::withMessages(['Your URL is invalid.']);
         }
     }
 

--- a/src/Collection/Complex/Uuid.php
+++ b/src/Collection/Complex/Uuid.php
@@ -111,7 +111,7 @@ class Uuid extends ValueObject
     protected function validate(): void
     {
         if (! str($this->value())->isUuid()) {
-            throw ValidationException::withMessages([__('UUID is invalid.')]);
+            throw ValidationException::withMessages(['UUID is invalid.']);
         }
     }
 }

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -159,6 +159,6 @@ abstract class ValueObject implements Arrayable, Immutable
      */
     public function __set(string $name, mixed $value): void
     {
-        throw new InvalidArgumentException(__(static::IMMUTABLE_MESSAGE));
+        throw new InvalidArgumentException(static::IMMUTABLE_MESSAGE);
     }
 }

--- a/tests/Unit/Complex/ClassStringTest.php
+++ b/tests/Unit/Complex/ClassStringTest.php
@@ -17,7 +17,7 @@ test('validation exception message is correct in class string', function () {
     try {
         new ClassString('');
     } catch (ValidationException $e) {
-        $this->assertSame(__('Class string cannot be empty.'), $e->getMessage());
+        $this->assertSame('Class string cannot be empty.', $e->getMessage());
     }
 });
 

--- a/tests/Unit/Complex/EmailTest.php
+++ b/tests/Unit/Complex/EmailTest.php
@@ -40,7 +40,7 @@ test('validation exception message is correct in email', function () {
     try {
         new Email('');
     } catch (ValidationException $e) {
-        $this->assertSame(__('Your email is invalid.'), $e->getMessage());
+        $this->assertSame('Your email is invalid.', $e->getMessage());
     }
 });
 

--- a/tests/Unit/Complex/FullNameTest.php
+++ b/tests/Unit/Complex/FullNameTest.php
@@ -82,13 +82,13 @@ test('validation exception message is correct in email', function () {
     try {
         new FullName('');
     } catch (ValidationException $e) {
-        $this->assertSame(__('Full name cannot be empty.'), $e->getMessage());
+        $this->assertSame('Full name cannot be empty.', $e->getMessage());
     }
 
     try {
         new FullName('Test');
     } catch (ValidationException $e) {
-        $this->assertSame(__('Full name should have a first name and last name.'), $e->getMessage());
+        $this->assertSame('Full name should have a first name and last name.', $e->getMessage());
     }
 });
 

--- a/tests/Unit/Complex/PhoneTest.php
+++ b/tests/Unit/Complex/PhoneTest.php
@@ -70,7 +70,7 @@ test('validation exception message is correct in phone', function () {
     try {
         new Phone('123');
     } catch (ValidationException $e) {
-        $this->assertSame(__('Your phone number is invalid.'), $e->getMessage());
+        $this->assertSame('Your phone number is invalid.', $e->getMessage());
     }
 });
 

--- a/tests/Unit/Complex/UrlTest.php
+++ b/tests/Unit/Complex/UrlTest.php
@@ -130,7 +130,7 @@ class TestUrl extends Url
         );
 
         if ($validator->fails()) {
-            throw ValidationException::withMessages([__('Your URL is invalid.')]);
+            throw ValidationException::withMessages(['Your URL is invalid.']);
         }
     }
 

--- a/tests/Unit/Complex/UuidTest.php
+++ b/tests/Unit/Complex/UuidTest.php
@@ -40,7 +40,7 @@ test('validation exception message is correct in uuid', function () {
     try {
         new Uuid('123123');
     } catch (ValidationException $e) {
-        $this->assertSame(__('UUID is invalid.'), $e->getMessage());
+        $this->assertSame('UUID is invalid.', $e->getMessage());
     }
 });
 


### PR DESCRIPTION
## About

Removes the explicit usage of translation helper & explicitly requires `illuminate/validation` package.

---