### PR TITLE
Swap `empty` with explicit string comparison

### DIFF
--- a/src/Artisan/stubs/value-object.stub
+++ b/src/Artisan/stubs/value-object.stub
@@ -67,7 +67,7 @@ class {{ class }} extends ValueObject
     {
         // TODO: Implement validate() method.
 
-        if (empty($this->value())) {
+        if ($this->value() === '') {
             throw ValidationException::withMessages(['Value of {{ class }} cannot be empty.']);
         }
     }

--- a/src/Collection/Complex/ClassString.php
+++ b/src/Collection/Complex/ClassString.php
@@ -114,7 +114,7 @@ class ClassString extends ValueObject
      */
     protected function validate(): void
     {
-        if (empty($this->value())) {
+        if ($this->value() === '') {
             throw ValidationException::withMessages(['Class string cannot be empty.']);
         }
     }

--- a/src/Collection/Complex/FullName.php
+++ b/src/Collection/Complex/FullName.php
@@ -102,7 +102,7 @@ class FullName extends Name
      */
     protected function validate(): void
     {
-        if (empty($this->value())) {
+        if ($this->value() === '') {
             throw ValidationException::withMessages(['Full name cannot be empty.']);
         }
 

--- a/src/Collection/Complex/TaxNumber.php
+++ b/src/Collection/Complex/TaxNumber.php
@@ -141,7 +141,7 @@ class TaxNumber extends ValueObject
      */
     protected function validate(): void
     {
-        if (empty($this->value())) {
+        if ($this->value() === '') {
             throw ValidationException::withMessages(['Tax number cannot be empty.']);
         }
     }

--- a/src/Collection/Primitive/Text.php
+++ b/src/Collection/Primitive/Text.php
@@ -74,7 +74,7 @@ class Text extends ValueObject
      */
     protected function validate(): void
     {
-        if (empty($this->value())) {
+        if ($this->value() === '') {
             throw new InvalidArgumentException('Text cannot be empty.');
         }
     }


### PR DESCRIPTION
Addresses the best comparison practices.

Read more in [this article](https://localheinz.com/articles/2023/05/10/avoiding-empty-in-php/).