### PR TITLE
Avoid object instantiation / stricter types

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -29,6 +29,16 @@
             "ignore": [
                 "MichaelRubel\\ValueObjects\\Artisan\\ValueObjectMakeCommand::getDefaultNamespace"
             ]
+        },
+        "CastString": {
+            "ignore": [
+                "MichaelRubel\\ValueObjects\\Collection\\Primitive\\Boolean::handleNonBoolean"
+            ]
+        },
+        "Ternary": {
+            "ignore": [
+                "MichaelRubel\\ValueObjects\\Collection\\Primitive\\Boolean::handleNonBoolean"
+            ]
         }
     }
 }

--- a/src/Collection/Primitive/Boolean.php
+++ b/src/Collection/Primitive/Boolean.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace MichaelRubel\ValueObjects\Collection\Primitive;
 
-use Illuminate\Support\Stringable;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use MichaelRubel\ValueObjects\ValueObject;
 
@@ -83,11 +83,9 @@ class Boolean extends ValueObject
      */
     protected function handleNonBoolean(int|string $value): void
     {
-        $string = new Stringable($value);
-
         $this->value = match (true) {
-            $string->contains($this->trueValues, ignoreCase: true) => true,
-            $string->contains($this->falseValues, ignoreCase: true) => false,
+            Str::contains($value, $this->trueValues, ignoreCase: true) => true,
+            Str::contains($value, $this->falseValues, ignoreCase: true) => false,
             default => throw new InvalidArgumentException('Invalid boolean.'),
         };
     }

--- a/src/Collection/Primitive/Boolean.php
+++ b/src/Collection/Primitive/Boolean.php
@@ -42,14 +42,14 @@ class Boolean extends ValueObject
      *
      * @var array
      */
-    protected array $trueValues = ['1', 'true', 1, 'on', 'yes'];
+    protected array $trueValues = ['1', 'true', 'on', 'yes'];
 
     /**
      * Values that represent `false` boolean.
      *
      * @var array
      */
-    protected array $falseValues = ['0', 'false', 0, 'off', 'no'];
+    protected array $falseValues = ['0', 'false', 'off', 'no'];
 
     /**
      * Create a new instance of the value object.
@@ -83,9 +83,11 @@ class Boolean extends ValueObject
      */
     protected function handleNonBoolean(int|string $value): void
     {
+        $string = is_string($value) ? $value : (string) $value;
+
         $this->value = match (true) {
-            Str::contains($value, $this->trueValues, ignoreCase: true) => true,
-            Str::contains($value, $this->falseValues, ignoreCase: true) => false,
+            Str::contains($string, $this->trueValues, ignoreCase: true) => true,
+            Str::contains($string, $this->falseValues, ignoreCase: true) => false,
             default => throw new InvalidArgumentException('Invalid boolean.'),
         };
     }

--- a/tests/Unit/Primitive/BooleanTest.php
+++ b/tests/Unit/Primitive/BooleanTest.php
@@ -11,6 +11,12 @@ test('boolean can accept integer', function () {
     $this->assertTrue($valueObject->value());
 });
 
+test('throws exception on invalid integer', function () {
+    $this->expectException(InvalidArgumentException::class);
+
+    new Boolean(2);
+});
+
 test('boolean can accept integer as a string', function () {
     $valueObject = new Boolean('0');
     $this->assertFalse($valueObject->value());
@@ -105,10 +111,10 @@ test('boolean is macroable', function () {
     Boolean::macro('getNegativeValues', fn () => $this->falseValues);
     $valueObject = new Boolean(1);
     $this->assertSame([
-        '1', 'true', 1, 'on', 'yes',
+        '1', 'true', 'on', 'yes',
     ], $valueObject->getPositiveValues());
     $this->assertSame([
-        '0', 'false', 0, 'off', 'no',
+        '0', 'false', 'off', 'no',
     ], $valueObject->getNegativeValues());
 });
 


### PR DESCRIPTION
## About

Removes Stringable object instantiation in `Boolean` and uses the static method directly from the `Str` class.

---